### PR TITLE
Add opt-in aggressive RAM reclaim, drop DISM from Deep Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,12 @@ A fast, lightweight Windows system cleaner and RAM optimizer. Single executable,
 | **8** | Installer Cache | Temporary Windows Installer patch cache files | **ON** |
 | **9** | DNS Resolver Cache | Flushes cached DNS records to refresh connection | **ON** |
 | **10** | RAM Optimization | Clears standby memory & dirty page lists | **ON** |
+| | ├ Flush modified list | Writes dirty pages to disk so they can be freed | **ON** |
+| | ├ Purge standby list | Frees the cached/standby page list | **ON** |
+| | ├ System file cache | Drops the kernel's cached file data | **OFF** (Opt-in) |
+| | └ Trim working sets | Pages out live app memory — frees the most, but apps re-read it from disk afterwards | **OFF** (Opt-in) |
 | **11** | Recycle Bin | Empties the Windows Recycle Bin | **OFF** (Opt-in) |
-| **12** | Deep Cleanup | System Component Cleanup (DISM) + Disk Cleanup | **OFF** (Resets after run) |
+| **12** | Deep Cleanup | Full Windows Disk Cleanup (cleanmgr, all handlers) | **OFF** (Resets after run) |
 
 Every step can be customized in the menu settings, and your choices are saved automatically.
 

--- a/cleaner.go
+++ b/cleaner.go
@@ -22,6 +22,7 @@ type StepResults struct {
 	RecycleBinFailed   bool
 	RecycleBinBytes    uint64
 	RamFreedMB         int64
+	Ram                RamResult
 	DeepCleanupRan     bool
 	DeepCleanupFailed  bool
 	StepCounts         [12]int64
@@ -354,7 +355,8 @@ func RunCleaningPipeline(cfg *Config) (results StepResults) {
 	if cfg.RamOptimize == 1 {
 		TypeLine("[10/12] Optimizing RAM...", 0)
 		fmt.Println("+---------------------------------------+")
-		results.RamFreedMB = RunRamCleaner()
+		results.Ram = RunRamCleaner(cfg)
+		results.RamFreedMB = results.Ram.FreedMB
 	} else {
 		fmt.Println("[10/12] RAM Optimization             - \x1b[36mSKIPPED\x1b[0m")
 	}
@@ -425,20 +427,6 @@ func RunCleaningPipeline(cfg *Config) (results StepResults) {
 				fmt.Println("  \x1b[36m[WARN]\x1b[0m cleanmgr.exe timed out (may still be running)")
 				results.DeepCleanupFailed = true
 			}
-		}
-
-		// --- Command 2: Dism.exe /online /Cleanup-Image /StartComponentCleanup /ResetBase ---
-		fmt.Println()
-		fmt.Println("  Running: Dism.exe /online /Cleanup-Image /StartComponentCleanup /ResetBase")
-		fmt.Println("  (This can take several minutes — live output below)")
-		cmd2 := exec.Command("Dism.exe", "/online", "/Cleanup-Image", "/StartComponentCleanup", "/ResetBase")
-		cmd2.Stdout = os.Stdout
-		cmd2.Stderr = os.Stderr
-		if err2 := cmd2.Run(); err2 != nil {
-			fmt.Printf("  \x1b[36m[WARN]\x1b[0m Dism.exe returned: %v\n", err2)
-			results.DeepCleanupFailed = true
-		} else {
-			fmt.Println("  \x1b[31m[OK]\x1b[0m Dism.exe component cleanup completed")
 		}
 
 		results.DeepCleanupRan = true

--- a/config.go
+++ b/config.go
@@ -21,6 +21,15 @@ type Config struct {
 	RamOptimize   int
 	RecycleBin    int
 	DeepCleanup   int // AGGRESSIVE — never persisted, always starts OFF
+
+	// --- RAM Optimization sub-options (only used when RamOptimize == 1) ---
+	// The first two are the original, safe behaviour and default ON.
+	// The last two free noticeably more memory but evict live/warm pages,
+	// so they default OFF and are opt-in.
+	RamFlushModified   int // write dirty pages to disk so they become freeable
+	RamPurgeStandby    int // free the standby (cached) page list
+	RamFileCache       int // flush the kernel/system file cache working set
+	RamTrimWorkingSets int // page out every process's working set (aggressive)
 }
 
 func DefaultConfig() *Config {
@@ -36,6 +45,11 @@ func DefaultConfig() *Config {
 		DnsFlush:      1,
 		RamOptimize:   1,
 		RecycleBin:    0, // OFF by default: destructive/irreversible, so opt-in only
+
+		RamFlushModified:   1,
+		RamPurgeStandby:    1,
+		RamFileCache:       0, // opt-in: drops kernel file cache
+		RamTrimWorkingSets: 0, // opt-in: aggressive, causes hard faults afterwards
 	}
 }
 
@@ -94,6 +108,14 @@ func LoadConfig(filePath string) (*Config, error) {
 			cfg.RamOptimize = val
 		case "RECYCLE_BIN":
 			cfg.RecycleBin = val
+		case "RAM_FLUSH_MODIFIED":
+			cfg.RamFlushModified = val
+		case "RAM_PURGE_STANDBY":
+			cfg.RamPurgeStandby = val
+		case "RAM_FILE_CACHE":
+			cfg.RamFileCache = val
+		case "RAM_TRIM_WORKING_SETS":
+			cfg.RamTrimWorkingSets = val
 		}
 	}
 
@@ -102,7 +124,7 @@ func LoadConfig(filePath string) (*Config, error) {
 
 func SaveConfig(filePath string, cfg *Config) error {
 	content := fmt.Sprintf(
-		"WIN_TEMP=%d\nUSER_TEMP=%d\nPREFETCH=%d\nERROR_REPORTS=%d\nDELIVERY_OPT=%d\nWIN_UPDATE=%d\nLOG_FILES=%d\nINSTALLER_TEMP=%d\nDNS_FLUSH=%d\nRAM_OPTIMIZE=%d\nRECYCLE_BIN=%d\n",
+		"WIN_TEMP=%d\nUSER_TEMP=%d\nPREFETCH=%d\nERROR_REPORTS=%d\nDELIVERY_OPT=%d\nWIN_UPDATE=%d\nLOG_FILES=%d\nINSTALLER_TEMP=%d\nDNS_FLUSH=%d\nRAM_OPTIMIZE=%d\nRECYCLE_BIN=%d\nRAM_FLUSH_MODIFIED=%d\nRAM_PURGE_STANDBY=%d\nRAM_FILE_CACHE=%d\nRAM_TRIM_WORKING_SETS=%d\n",
 		cfg.WinTemp,
 		cfg.UserTemp,
 		cfg.Prefetch,
@@ -114,6 +136,10 @@ func SaveConfig(filePath string, cfg *Config) error {
 		cfg.DnsFlush,
 		cfg.RamOptimize,
 		cfg.RecycleBin,
+		cfg.RamFlushModified,
+		cfg.RamPurgeStandby,
+		cfg.RamFileCache,
+		cfg.RamTrimWorkingSets,
 	)
 	return os.WriteFile(filePath, []byte(content), 0644)
 }
@@ -142,6 +168,16 @@ func (c *Config) GetVal(index int) int {
 		return c.RamOptimize
 	case 11:
 		return c.RecycleBin
+	// 101-104: RAM Optimization sub-options. Kept outside the 1..11 range so
+	// the main-menu loop over the top-level steps is unaffected.
+	case 101:
+		return c.RamFlushModified
+	case 102:
+		return c.RamPurgeStandby
+	case 103:
+		return c.RamFileCache
+	case 104:
+		return c.RamTrimWorkingSets
 	default:
 		return 0
 	}
@@ -171,6 +207,14 @@ func (c *Config) SetVal(index int, val int) {
 		c.RamOptimize = val
 	case 11:
 		c.RecycleBin = val
+	case 101:
+		c.RamFlushModified = val
+	case 102:
+		c.RamPurgeStandby = val
+	case 103:
+		c.RamFileCache = val
+	case 104:
+		c.RamTrimWorkingSets = val
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -53,14 +53,17 @@ func main() {
 		ClearScreen()
 		promptRow := DrawMainMenu(cfg, osP1, osP2, host, user)
 
-		// Live CPU/Memory stats row starts updating only once the menu is
-		// fully drawn (so its first tick doesn't race the initial print),
-		// and is explicitly stopped before ANY transition away from this
+		// The prompt is printed BEFORE the live stats row starts: the stats
+		// goroutine parks the cursor at the prompt's row/column after every
+		// repaint, so the prompt text must already be on screen or its first
+		// paint would push the prompt out of column 1.
+		fmt.Print("  > ")
+
+		// Live CPU/Memory stats row - painted once immediately, then every
+		// second. Explicitly stopped before ANY transition away from this
 		// screen - Settings, running the cleaner, or exiting - so it can
 		// never write to a screen that's no longer the main menu.
 		statsStopCh := StartLiveStatsRow(promptRow)
-
-		fmt.Print("  > ")
 
 		// Single-key input loop: only ENTER (run) and F (settings) are
 		// valid. Everything else is silently ignored — no echo, no cursor
@@ -91,8 +94,11 @@ func main() {
 		results := RunCleaningPipeline(cfg)
 		PrintSummary(cfg, results)
 
+		// WaitForEnter flushes anything typed during the run first, so ENTER
+		// presses made while cleaning was in progress can't close the window
+		// before the summary has been read.
 		fmt.Print("Press ENTER to exit...")
-		ReadSingleKey()
+		WaitForEnter()
 		os.Exit(0)
 	}
 }

--- a/ramclean.go
+++ b/ramclean.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math"
+	"strings"
 	"syscall"
 	"time"
 	"unsafe"
@@ -13,9 +14,15 @@ import (
 var (
 	modntdll                   = windows.NewLazySystemDLL("ntdll.dll")
 	modkernel32                = windows.NewLazySystemDLL("kernel32.dll")
+	modpsapi                   = windows.NewLazySystemDLL("psapi.dll")
+	moduser32                  = windows.NewLazySystemDLL("user32.dll")
 	procNtSetSystemInformation = modntdll.NewProc("NtSetSystemInformation")
 	procGlobalMemoryStatusEx   = modkernel32.NewProc("GlobalMemoryStatusEx")
 	procGetSystemTimes         = modkernel32.NewProc("GetSystemTimes")
+	procSetSystemFileCacheSize = modkernel32.NewProc("SetSystemFileCacheSize")
+	procEmptyWorkingSet        = modpsapi.NewProc("EmptyWorkingSet")
+	procGetForegroundWindow    = moduser32.NewProc("GetForegroundWindow")
+	procGetWindowThreadProcId  = moduser32.NewProc("GetWindowThreadProcessId")
 )
 
 const (
@@ -43,6 +50,21 @@ type MemoryStats struct {
 	UsedPercent float64
 }
 
+// RamResult carries everything the end-of-run summary needs to report about
+// step [10] - the totals plus which of the four sub-operations actually ran,
+// so the summary can attribute the numbers instead of just showing an MB delta.
+type RamResult struct {
+	FreedMB      int64
+	BeforePct    float64
+	AfterPct     float64
+	DropPct      float64
+	OpsRun       []string // short labels of the sub-options that executed
+	Trimmed      int      // processes trimmed (working-set trim only)
+	TrimSkipped  int      // processes skipped (protected/no access)
+	PrivFailed   bool     // could not enable SeProfileSingleProcessPrivilege
+	NothingToRun bool     // all four sub-options were OFF
+}
+
 type SystemStats struct {
 	CpuLoad uint64
 	UsedGB  float64
@@ -50,7 +72,14 @@ type SystemStats struct {
 	Pct     uint64
 }
 
+// EnablePrivilege enables SeProfileSingleProcessPrivilege, which is what
+// NtSetSystemInformation(SystemMemoryListInformation) requires.
 func EnablePrivilege() bool {
+	return enablePrivilege("SeProfileSingleProcessPrivilege")
+}
+
+// enablePrivilege enables a named privilege on the current process token.
+func enablePrivilege(name string) bool {
 	var token windows.Token
 	err := windows.OpenProcessToken(windows.CurrentProcess(), windows.TOKEN_ADJUST_PRIVILEGES|windows.TOKEN_QUERY, &token)
 	if err != nil {
@@ -58,7 +87,7 @@ func EnablePrivilege() bool {
 	}
 	defer token.Close()
 
-	privName, _ := windows.UTF16PtrFromString("SeProfileSingleProcessPrivilege")
+	privName, _ := windows.UTF16PtrFromString(name)
 	var luid windows.LUID
 	err = windows.LookupPrivilegeValue(nil, privName, &luid)
 	if err != nil {
@@ -97,6 +126,122 @@ func PurgeStandbyList() int32 {
 		unsafe.Sizeof(cmd),
 	)
 	return int32(r1)
+}
+
+// PurgeSystemFileCache flushes the kernel's system file cache working set by
+// calling SetSystemFileCacheSize with min/max set to (SIZE_T)-1, which is the
+// documented "reset the cache" sentinel. This only drops cached file data -
+// no process ever loses a page it is currently working on - so it is the safe
+// half of what vendor "memory booster" tools do.
+//
+// Requires SeIncreaseQuotaPrivilege.
+func PurgeSystemFileCache() bool {
+	// LazyProc.Call panics if the export can't be resolved, so resolve first.
+	if err := procSetSystemFileCacheSize.Find(); err != nil {
+		return false
+	}
+	if !enablePrivilege("SeIncreaseQuotaPrivilege") {
+		return false
+	}
+	minusOne := ^uintptr(0) // (SIZE_T)-1
+	r1, _, _ := procSetSystemFileCacheSize.Call(minusOne, minusOne, 0)
+	return r1 != 0
+}
+
+// protectedProcNames are processes we never trim. Trimming these either fails
+// outright (they are protected) or hurts responsiveness far more than the
+// memory it reclaims is worth.
+var protectedProcNames = map[string]bool{
+	"system":             true,
+	"registry":           true,
+	"memory compression": true,
+	"smss.exe":           true,
+	"csrss.exe":          true,
+	"wininit.exe":        true,
+	"winlogon.exe":       true,
+	"services.exe":       true,
+	"lsass.exe":          true,
+	"msmpeng.exe":        true,
+	"dwm.exe":            true,
+}
+
+// getForegroundPID returns the PID owning the current foreground window, or 0
+// if there isn't one. That process is skipped during a working-set trim so the
+// app the user is actually looking at doesn't get paged out from under them.
+func getForegroundPID() uint32 {
+	if procGetForegroundWindow.Find() != nil || procGetWindowThreadProcId.Find() != nil {
+		return 0
+	}
+	hwnd, _, _ := procGetForegroundWindow.Call()
+	if hwnd == 0 {
+		return 0
+	}
+	var pid uint32
+	procGetWindowThreadProcId.Call(hwnd, uintptr(unsafe.Pointer(&pid)))
+	return pid
+}
+
+// TrimAllWorkingSets calls EmptyWorkingSet on every accessible process, which
+// forces its private working set out to the pagefile/standby list. This is the
+// operation that makes vendor cleaners (ASUS, etc.) show a large drop in "in
+// use" memory - but those pages were live, so the owning apps will hard-fault
+// them straight back in on next use. Hence: opt-in only.
+//
+// Skipped: PID 0/4, our own process, the foreground window's process, and the
+// protected system processes above.
+//
+// Returns (trimmed, skipped).
+func TrimAllWorkingSets() (int, int) {
+	if err := procEmptyWorkingSet.Find(); err != nil {
+		return 0, 0
+	}
+
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0, 0
+	}
+	defer windows.CloseHandle(snapshot)
+
+	selfPID := uint32(windows.GetCurrentProcessId())
+	fgPID := getForegroundPID()
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return 0, 0
+	}
+
+	trimmed, skipped := 0, 0
+	for {
+		pid := entry.ProcessID
+		name := strings.ToLower(windows.UTF16ToString(entry.ExeFile[:]))
+
+		if pid > 4 && pid != selfPID && pid != fgPID && !protectedProcNames[name] {
+			h, openErr := windows.OpenProcess(
+				windows.PROCESS_SET_QUOTA|windows.PROCESS_QUERY_LIMITED_INFORMATION,
+				false, pid,
+			)
+			if openErr != nil {
+				skipped++
+			} else {
+				r1, _, _ := procEmptyWorkingSet.Call(uintptr(h))
+				if r1 != 0 {
+					trimmed++
+				} else {
+					skipped++
+				}
+				windows.CloseHandle(h)
+			}
+		} else {
+			skipped++
+		}
+
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	return trimmed, skipped
 }
 
 func GetMemoryStats() MemoryStats {
@@ -195,42 +340,115 @@ func GetSystemStats() SystemStats {
 	}
 }
 
-func RunRamCleaner() int64 {
+// RunRamCleaner runs whichever of the four memory operations are enabled in
+// cfg, in the order that makes each one count: working sets are trimmed and
+// dirty pages flushed FIRST so those pages land on the standby list, and the
+// standby purge runs LAST so it sweeps everything the earlier steps produced.
+func RunRamCleaner(cfg *Config) RamResult {
 	before := GetMemoryStats()
+	result := RamResult{BeforePct: before.UsedPercent, AfterPct: before.UsedPercent}
+
+	// Build the list of enabled operations up front so the step counter
+	// ("Step 2/4") reflects what's actually going to run.
+	type ramStep struct {
+		title string
+		note  string
+		run   func()
+	}
+	var steps []ramStep
+
+	if cfg.RamTrimWorkingSets == 1 {
+		result.OpsRun = append(result.OpsRun, "trim")
+		steps = append(steps, ramStep{
+			"Trimming process working sets...",
+			"(Paging out live app memory - skips the foreground app)",
+			func() {
+				trimmed, skipped := TrimAllWorkingSets()
+				result.Trimmed = trimmed
+				result.TrimSkipped = skipped
+				if trimmed > 0 {
+					fmt.Printf("    \x1b[31m%d processes trimmed, %d skipped (protected/no access)\x1b[0m\n", trimmed, skipped)
+				} else {
+					fmt.Printf("    \x1b[33mNo processes trimmed (%d skipped) - run as Administrator\x1b[0m\n", skipped)
+				}
+			},
+		})
+	}
+
+	if cfg.RamFlushModified == 1 {
+		result.OpsRun = append(result.OpsRun, "flush")
+		steps = append(steps, ramStep{
+			"Flushing modified page list...",
+			"(Writing dirty pages to disk so they can be freed)",
+			func() {
+				res := FlushModifiedList()
+				status := FormatNTSTATUS(res)
+				if res == 0 {
+					fmt.Printf("    \x1b[31mModified page list flushed - NTSTATUS: %s\x1b[0m\n", status)
+				} else {
+					fmt.Printf("    \x1b[33mFlushModifiedList returned NTSTATUS: %s\x1b[0m\n", status)
+				}
+			},
+		})
+	}
+
+	if cfg.RamFileCache == 1 {
+		result.OpsRun = append(result.OpsRun, "file cache")
+		steps = append(steps, ramStep{
+			"Flushing system file cache...",
+			"(Dropping the kernel's cached file data - safe, cache only)",
+			func() {
+				if PurgeSystemFileCache() {
+					fmt.Println("    \x1b[31mSystem file cache flushed\x1b[0m")
+				} else {
+					fmt.Println("    \x1b[33mCould not flush system file cache - run as Administrator\x1b[0m")
+				}
+			},
+		})
+	}
+
+	if cfg.RamPurgeStandby == 1 {
+		result.OpsRun = append(result.OpsRun, "standby")
+		steps = append(steps, ramStep{
+			"Purging standby list...",
+			"(Freeing cached/standby memory - this is the main operation)",
+			func() {
+				res := PurgeStandbyList()
+				status := FormatNTSTATUS(res)
+				if res == 0 {
+					fmt.Printf("    \x1b[31mStandby list purged - NTSTATUS: %s\x1b[0m\n", status)
+				} else {
+					fmt.Printf("    \x1b[33mPurgeStandbyList returned NTSTATUS: %s\x1b[0m\n", status)
+				}
+			},
+		})
+	}
+
+	if len(steps) == 0 {
+		fmt.Println()
+		fmt.Println("    \x1b[33mAll RAM Optimization sub-options are OFF - nothing to do\x1b[0m")
+		result.NothingToRun = true
+		return result
+	}
+
+	total := len(steps) + 1
 
 	// --- Step 1: Enable privilege ---
 	fmt.Println()
-	fmt.Println("  \x1b[36m[Step 1/3] Enabling SeProfileSingleProcessPrivilege...\x1b[0m")
-	privOk := EnablePrivilege()
-	if privOk {
+	fmt.Printf("  \x1b[36m[Step 1/%d] Enabling SeProfileSingleProcessPrivilege...\x1b[0m\n", total)
+	if EnablePrivilege() {
 		fmt.Println("    \x1b[31mPrivilege enabled successfully\x1b[0m")
 	} else {
 		fmt.Println("    \x1b[33mFAILED to enable privilege\x1b[0m")
-		return 0
+		result.PrivFailed = true
+		return result
 	}
 
-	// --- Step 2: Flush modified page list ---
-	fmt.Println()
-	fmt.Println("  \x1b[36m[Step 2/3] Flushing modified page list...\x1b[0m")
-	fmt.Println("    (Writing dirty pages to disk so they can be freed)")
-	res1 := FlushModifiedList()
-	status1 := FormatNTSTATUS(res1)
-	if res1 == 0 {
-		fmt.Printf("    \x1b[31mModified page list flushed - NTSTATUS: %s\x1b[0m\n", status1)
-	} else {
-		fmt.Printf("    \x1b[33mFlushModifiedList returned NTSTATUS: %s\x1b[0m\n", status1)
-	}
-
-	// --- Step 3: Purge standby list ---
-	fmt.Println()
-	fmt.Println("  \x1b[36m[Step 3/3] Purging standby list...\x1b[0m")
-	fmt.Println("    (Freeing cached/standby memory - this is the main operation)")
-	res2 := PurgeStandbyList()
-	status2 := FormatNTSTATUS(res2)
-	if res2 == 0 {
-		fmt.Printf("    \x1b[31mStandby list purged - NTSTATUS: %s\x1b[0m\n", status2)
-	} else {
-		fmt.Printf("    \x1b[33mPurgeStandbyList returned NTSTATUS: %s\x1b[0m\n", status2)
+	for i, s := range steps {
+		fmt.Println()
+		fmt.Printf("  \x1b[36m[Step %d/%d] %s\x1b[0m\n", i+2, total, s.title)
+		fmt.Printf("    %s\n", s.note)
+		s.run()
 	}
 
 	time.Sleep(800 * time.Millisecond)
@@ -245,6 +463,10 @@ func RunRamCleaner() int64 {
 	}
 
 	dropPct := math.Round((before.UsedPercent-after.UsedPercent)*10) / 10
+
+	result.FreedMB = freedMB
+	result.AfterPct = after.UsedPercent
+	result.DropPct = dropPct
 
 	fmt.Println()
 	fmt.Println("  +---------------------------------------+")
@@ -263,11 +485,9 @@ func RunRamCleaner() int64 {
 		fmt.Println("    \x1b[33mStatus       : Try closing background apps and run again\x1b[0m")
 	}
 
-	stats := GetSystemStats()
-	fmt.Println()
-	fmt.Println("  +---------------------------------------+")
-	fmt.Printf("  \x1b[31mCPU : %d%%  -  Memory : %.2f/%.2f GB (%d%%)\x1b[0m\n", stats.CpuLoad, stats.UsedGB, stats.TotalGB, stats.Pct)
-	fmt.Println("  +---------------------------------------+")
+	// No CPU/Memory box here on purpose: the same numbers are already in the
+	// SYSTEM RESULTS block above and in the end-of-run summary, and the live
+	// row on the main menu is the one place stats belong.
 
-	return freedMB
+	return result
 }

--- a/ui.go
+++ b/ui.go
@@ -16,6 +16,8 @@ var (
 	procGetch           = modmsvcrt.NewProc("_getch")
 	modkernel32Title    = windows.NewLazySystemDLL("kernel32.dll")
 	procSetConsoleTitle = modkernel32Title.NewProc("SetConsoleTitleW")
+
+	procFlushConsoleInputBuffer = modkernel32Title.NewProc("FlushConsoleInputBuffer")
 )
 
 const (
@@ -41,7 +43,20 @@ const (
 // any screen transition (Settings, running the cleaning pipeline, exit),
 // so it can never race with ClearScreen()/DrawMainMenu() being called
 // again or write to a screen that's no longer the main menu.
-const liveStatsRow = 7
+// Both the main menu and the settings screen reserve row 2 (directly above
+// the first "+---+" box line) for the live stats, so a single constant and a
+// single painter cover both screens.
+const liveStatsRow = 2
+
+// liveStats is the handle to a running stats-row painter. It carries a done
+// channel so StopLiveStatsRow can WAIT for the goroutine to actually exit -
+// without that, close(stop) returns immediately while the goroutine may still
+// be inside a paint, and that stray write lands on whatever screen was drawn
+// next (it used to overwrite the first row of the settings list).
+type liveStats struct {
+	stop chan struct{}
+	done chan struct{}
+}
 
 // StartLiveStatsRow launches a goroutine that repaints row 7 every second
 // with "CPU : {%} - MEMORY: {used/total GB} {pct%}". Returns a
@@ -54,51 +69,80 @@ const liveStatsRow = 7
 // write happens concurrently with a blocking stdin read on the main
 // goroutine and we want the cursor's final position to be deterministic
 // rather than depend on save/restore semantics under concurrent access.
-func StartLiveStatsRow(promptRow int) chan struct{} {
-	stopCh := make(chan struct{})
+func StartLiveStatsRow(promptRow int) *liveStats {
+	ls := &liveStats{
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
 
 	go func() {
+		// done is closed last so Stop can't return while a paint is
+		// still in flight.
+		defer close(ls.done)
 		defer func() {
 			// Never let a stats-refresh panic take down the whole app;
 			// this is a cosmetic feature, not a critical path.
 			_ = recover()
 		}()
 
+		// Paint once immediately. DrawMainMenu leaves the stats row blank so
+		// there is exactly ONE stats line on screen - this live one - rather
+		// than a static line that a later tick paints over. Without this
+		// first paint the row would sit empty for a full second.
+		paint := func() {
+			stats := GetSystemStats()
+			line := fmt.Sprintf(
+				"  CPU : %s%d%%%s  -  MEMORY: %s%.2f/%.2f GB%s %s%d%%%s",
+				RED, stats.CpuLoad, RST,
+				RED, stats.UsedGB, stats.TotalGB, RST,
+				RED, stats.Pct, RST,
+			)
+
+			// Jump to the fixed stats row, clear only that line, print
+			// new content, then explicitly return the cursor to the
+			// input prompt's row/column so the blocking read on the main
+			// goroutine still shows its cursor in the right place. No
+			// save/restore - both positions are known and fixed, so we
+			// just state them directly each tick.
+			fmt.Printf("\x1b[%d;1H\x1b[2K%s\x1b[%d;5H", liveStatsRow, line, promptRow)
+		}
+
+		paint()
+
 		ticker := time.NewTicker(1 * time.Second)
 		defer ticker.Stop()
 
 		for {
 			select {
-			case <-stopCh:
+			case <-ls.stop:
 				return
 			case <-ticker.C:
-				stats := GetSystemStats()
-				line := fmt.Sprintf(
-					"  CPU : %s%d%%%s  -  MEMORY: %s%.2f/%.2f GB%s %s%d%%%s",
-					RED, stats.CpuLoad, RST,
-					RED, stats.UsedGB, stats.TotalGB, RST,
-					RED, stats.Pct, RST,
-				)
-
-				// Jump to the fixed stats row, clear only that line, print
-				// new content, then explicitly return the cursor to the
-				// input prompt's row/column so the blocking ReadString on
-				// the main goroutine still shows its cursor in the right
-				// place. No save/restore - both positions are known and
-				// fixed, so we just state them directly each tick.
-				fmt.Printf("\x1b[%d;1H\x1b[2K%s\x1b[%d;5H", liveStatsRow, line, promptRow)
+				// A tick and a stop can become ready in the same instant,
+				// and select picks between ready cases at random - so
+				// re-check stop before painting, or the final tick can
+				// still write to a screen that's already been replaced.
+				select {
+				case <-ls.stop:
+					return
+				default:
+				}
+				paint()
 			}
 		}
 	}()
 
-	return stopCh
+	return ls
 }
 
-// StopLiveStatsRow signals the goroutine started by StartLiveStatsRow to
-// stop. Safe to call even if the row happens to be mid-tick; the select
-// in the goroutine picks up stopCh on the next loop iteration.
-func StopLiveStatsRow(stopCh chan struct{}) {
-	close(stopCh)
+// StopLiveStatsRow stops the painter and BLOCKS until it has actually exited,
+// guaranteeing no further writes to the screen once this returns. Callers rely
+// on that before drawing a different screen.
+func StopLiveStatsRow(ls *liveStats) {
+	if ls == nil {
+		return
+	}
+	close(ls.stop)
+	<-ls.done
 }
 
 func EnableVirtualTerminalProcessing() {
@@ -166,6 +210,36 @@ func ReadSingleKey() rune {
 	return rune(r1)
 }
 
+// FlushKeyBuffer discards every keystroke sitting in the console input queue.
+//
+// Keys pressed WHILE the cleaner is running don't disappear - Windows queues
+// them, and the next read consumes them instantly. So mashing ENTER during a
+// run used to fly straight through the "Press ENTER to exit" prompt and close
+// the window before the summary could be read. Flushing immediately before
+// that prompt means only a press made AFTER the run finished can dismiss it.
+func FlushKeyBuffer() {
+	if procFlushConsoleInputBuffer.Find() != nil {
+		return
+	}
+	h, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
+	if err != nil {
+		return
+	}
+	procFlushConsoleInputBuffer.Call(uintptr(h))
+}
+
+// WaitForEnter blocks until ENTER is actually pressed, ignoring every other
+// key. Pending keystrokes are flushed first, so this cannot be satisfied by
+// something typed earlier.
+func WaitForEnter() {
+	FlushKeyBuffer()
+	for {
+		if ReadSingleKey() == 13 {
+			return
+		}
+	}
+}
+
 func GetCfgDispName(index int) string {
 	switch index {
 	case 1:
@@ -190,10 +264,24 @@ func GetCfgDispName(index int) string {
 		return "[10] RAM Optimization        "
 	case 11:
 		return "[11] Empty Recycle Bin       "
+	// 101-104: RAM Optimization sub-options, shown indented under [10].
+	// All four strings are the same length so their ON/OFF column lines up.
+	case 101:
+		return "  - Flush modified list  (dirty pages to disk)"
+	case 102:
+		return "  - Purge standby list   (frees cached memory)"
+	case 103:
+		return "  - System file cache    (kernel disk cache)  "
+	case 104:
+		return "  - Trim working sets    (app memory, harsh)  "
 	default:
 		return ""
 	}
 }
+
+// ramSubOptions are the config indices of the RAM Optimization sub-toggles,
+// in display order.
+var ramSubOptions = []int{101, 102, 103, 104}
 
 // DrawMainMenu prints the main menu and returns the screen row number
 // where the "  > " input prompt will be printed immediately after this
@@ -213,19 +301,17 @@ func DrawMainMenu(cfg *Config, osP1, osP2, host, user string) int {
 	}
 
 	pln()
+	// Reserve the stats row but leave it EMPTY - StartLiveStatsRow paints it
+	// immediately and then once a second. Printing a static line here too
+	// would mean two stats lines on screen (a stale one and a live one).
+	// It sits above the box so both screens show stats in the same place.
+	statsRowNum := row + 1
+	pln()
 	pln("+---------------------------------------+")
 	pln("            QUIESCE")
 	pln("+---------------------------------------+")
 	pf("  %sSibtainOcn ~ %sQuiesce v2.1%s\n", WHITE, RED, RST)
 	pf("  %s%s%s%s%s\n", WHITE, osP1, RED, osP2, RST)
-	// Fetch real stats immediately so the first frame is never blank.
-	initStats := GetSystemStats()
-	statsRowNum := row + 1
-	pf("  CPU : %s%d%%%s  -  MEMORY: %s%.2f/%.2f GB%s %s%d%%%s\n",
-		RED, initStats.CpuLoad, RST,
-		RED, initStats.UsedGB, initStats.TotalGB, RST,
-		RED, initStats.Pct, RST,
-	)
 	pln("+---------------------------------------+")
 	pln()
 	pf("%sThis will clean:%s\n", WHITE, RST)
@@ -237,6 +323,17 @@ func DrawMainMenu(cfg *Config, osP1, osP2, host, user string) int {
 			pf("  %s : %s[ON]%s\n", disp, RED, RST)
 		} else {
 			pf("  %s : %s[OFF]%s\n", disp, CYAN, RST)
+		}
+
+		// Show which RAM operations will actually run, indented under [10].
+		if i == 10 && val == 1 {
+			for _, sub := range ramSubOptions {
+				if cfg.GetVal(sub) == 1 {
+					pf("  %s : %s[ON]%s\n", GetCfgDispName(sub), RED, RST)
+				} else {
+					pf("  %s : %s[OFF]%s\n", GetCfgDispName(sub), CYAN, RST)
+				}
+			}
 		}
 	}
 
@@ -269,77 +366,111 @@ func DrawMainMenu(cfg *Config, osP1, osP2, host, user string) int {
 }
 
 func RunSettingsScreen(cfg *Config, configFilePath string) {
-	sel := 1
+	// Navigable rows, in display order: steps 1-10, the four RAM
+	// sub-options indented under [10], then step 11 and Deep Cleanup (12).
+	entries := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	entries = append(entries, ramSubOptions...)
+	entries = append(entries, 11, 12)
+
+	// sel is a position in entries, not a config index.
+	sel := 0
 
 	for {
-		ClearScreen()
-		fmt.Println()
-		fmt.Printf("%s+---------------------------------------+%s\n", WHITE, RST)
-		fmt.Printf("%s         CONFIGURE CLEANING OPTIONS%s\n", WHITE, RST)
-		fmt.Printf("%s+---------------------------------------+%s\n", WHITE, RST)
-		fmt.Printf("  %sW%s = Up  |  %sS%s = Down  |  %sA%s = OFF  |  %sD%s = ON  |  %sE%s = Save\n", WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST)
-		fmt.Println()
+		// Row counter, same technique as DrawMainMenu: the prompt row is
+		// computed as the screen is drawn rather than hand-counted, so the
+		// live stats painter always parks the cursor in the right place.
+		row := 0
+		pln := func(a ...interface{}) {
+			fmt.Println(a...)
+			row++
+		}
+		pf := func(format string, a ...interface{}) {
+			fmt.Printf(format, a...)
+			row++
+		}
 
-		for i := 1; i <= 11; i++ {
-			disp := GetCfgDispName(i)
-			val := cfg.GetVal(i)
+		ClearScreen()
+		pln()
+		// Reserved (empty) stats row - painted live, above the box, exactly
+		// as on the main menu.
+		statsRowNum := row + 1
+		pln()
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
+		pf("%s         CONFIGURE CLEANING OPTIONS%s\n", WHITE, RST)
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
+		pf("  %sW%s = Up  |  %sS%s = Down  |  %sA%s = OFF  |  %sD%s = ON  |  %sE%s = Save\n", WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST)
+		pln()
+
+		if statsRowNum != liveStatsRow {
+			pf("\x1b[33m[WARN]\x1b[0m liveStatsRow constant (%d) doesn't match actual row (%d). Update liveStatsRow in ui.go.\n", liveStatsRow, statsRowNum)
+		}
+
+		for pos, idx := range entries {
+			row++
 			a := "   "
-			if sel == i {
+			if sel == pos {
 				a = fmt.Sprintf(" %s<<<<<%s", YELLOW, RST)
 			}
 
-			if val == 1 {
+			// Deep Cleanup (12) isn't part of Config's GetVal/SetVal - it is
+			// never persisted, so it's read and drawn separately.
+			if idx == 12 {
+				if cfg.DeepCleanup == 1 {
+					fmt.Printf("   [12] Deep Cleanup - %sRUN ONCE%s  : %s[ON]%s%s\n", RED, RST, RED, RST, a)
+				} else {
+					fmt.Printf("   [12] Deep Cleanup - %sRUN ONCE%s  : %s[OFF]%s%s\n", RED, RST, CYAN, RST, a)
+				}
+				continue
+			}
+
+			disp := GetCfgDispName(idx)
+			if cfg.GetVal(idx) == 1 {
 				fmt.Printf("   %s : %s[ON]%s%s\n", disp, RED, RST, a)
 			} else {
 				fmt.Printf("   %s : %s[OFF]%s%s\n", disp, CYAN, RST, a)
 			}
 		}
 
-		// Deep Cleanup — inline right after cleaning options (sel=12)
-		{
-			deepVal := cfg.DeepCleanup
-			a := "   "
-			if sel == 12 {
-				a = fmt.Sprintf(" %s<<<<<%s", YELLOW, RST)
-			}
-			if deepVal == 1 {
-				fmt.Printf("   [12] Deep Cleanup - %sRUN ONCE%s  : %s[ON]%s%s\n", RED, RST, RED, RST, a)
-			} else {
-				fmt.Printf("   [12] Deep Cleanup - %sRUN ONCE%s  : %s[OFF]%s%s\n", RED, RST, CYAN, RST, a)
-			}
-		}
+		pln()
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
+		pf("  Press %sE%s to Save & Return\n", WHITE, RST)
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
 
-		fmt.Println()
-		fmt.Printf("%s+---------------------------------------+%s\n", WHITE, RST)
-		fmt.Printf("  Press %sE%s to Save & Return\n", WHITE, RST)
-		fmt.Printf("%s+---------------------------------------+%s\n", WHITE, RST)
+		// Prompt first, then the painter - the painter parks the cursor at
+		// the prompt's column, so the prompt has to already be on screen.
 		fmt.Print("  > ")
+		statsStop := StartLiveStatsRow(row + 1)
 
 		ch := ReadSingleKey()
+
+		// Stop (and WAIT for) the painter before this screen is redrawn or
+		// replaced, so it can never write over the next screen.
+		StopLiveStatsRow(statsStop)
+
 		chStr := strings.ToLower(string(ch))
 
 		switch chStr {
 		case "w":
 			sel--
-			if sel < 1 {
-				sel = 12
+			if sel < 0 {
+				sel = len(entries) - 1
 			}
 		case "s":
 			sel++
-			if sel > 12 {
-				sel = 1
+			if sel > len(entries)-1 {
+				sel = 0
 			}
 		case "a":
-			if sel == 12 {
+			if entries[sel] == 12 {
 				cfg.DeepCleanup = 0
 			} else {
-				cfg.SetVal(sel, 0)
+				cfg.SetVal(entries[sel], 0)
 			}
 		case "d":
-			if sel == 12 {
+			if entries[sel] == 12 {
 				cfg.DeepCleanup = 1
 			} else {
-				cfg.SetVal(sel, 1)
+				cfg.SetVal(entries[sel], 1)
 			}
 		case "e":
 			// Save config — DeepCleanup is intentionally NOT saved
@@ -390,12 +521,29 @@ func PrintSummary(cfg *Config, results StepResults) {
 			} else if s.idx == 9 {
 				fmt.Printf("  %-5s%s : flushed\n", label, s.name)
 			} else if s.idx == 10 {
-				if results.RamFreedMB > 0 {
-					fmt.Printf("  %-5s%s : %d MB freed\n", label, s.name, results.RamFreedMB)
-				} else if results.RamFreedMB == 0 {
+				r := results.Ram
+				switch {
+				case r.NothingToRun:
+					fmt.Printf("  %-5s%s : %sall sub-options OFF%s\n", label, s.name, CYAN, RST)
+				case r.PrivFailed:
+					fmt.Printf("  %-5s%s : %sfailed (no privilege)%s\n", label, s.name, CYAN, RST)
+				case r.FreedMB > 0:
+					fmt.Printf("  %-5s%s : %d MB freed (%.1f%% -> %.1f%%, -%.1f%%)\n",
+						label, s.name, r.FreedMB, r.BeforePct, r.AfterPct, r.DropPct)
+				case r.FreedMB == 0:
 					fmt.Printf("  %-5s%s : 0 MB (already optimal)\n", label, s.name)
-				} else {
-					fmt.Printf("  %-5s%s : %s%d MB (background app allocated)%s\n", label, s.name, CYAN, results.RamFreedMB, RST)
+				default:
+					fmt.Printf("  %-5s%s : %s%d MB (background app allocated)%s\n", label, s.name, CYAN, r.FreedMB, RST)
+				}
+
+				// Attribute the number: which of the four operations ran,
+				// and how many processes the trim actually reached.
+				if !r.NothingToRun && !r.PrivFailed && len(r.OpsRun) > 0 {
+					detail := strings.Join(r.OpsRun, ", ")
+					if r.Trimmed > 0 || r.TrimSkipped > 0 {
+						detail = fmt.Sprintf("%s [%d procs trimmed, %d skipped]", detail, r.Trimmed, r.TrimSkipped)
+					}
+					fmt.Printf("       %sran: %s%s\n", CYAN, detail, RST)
 				}
 			} else if s.idx == 11 {
 				if results.RecycleBinFailed {


### PR DESCRIPTION
Deep Cleanup (option 12) now runs cleanmgr only. The DISM /StartComponentCleanup /ResetBase pass is removed: it took minutes, duplicated work cleanmgr already does, and permanently blocks uninstalling superseded updates.

RAM Optimization (option 10) gains two opt-in operations, so it can reclaim what vendor tools like ASUS Armoury Crate do instead of only purging the standby list:

  - System file cache  - SetSystemFileCacheSize((SIZE_T)-1, ...) drops the kernel's cached file data. Cache only, so nothing loses a page it is actively using.
  - Trim working sets  - EmptyWorkingSet on every accessible process, which is what produces the large "in use" drop those tools show. Skips PID <= 4, our own process, the foreground window's process, and protected system processes (lsass, csrss, dwm, Defender, ...).

Both default OFF: the trim evicts live pages that apps hard-fault back from disk, trading a brief stutter for a bigger number. The original flush/purge pair stays ON and unchanged.

All four are separate toggles in the config menu, each labelled with its purpose, navigable inline under [10] and persisted to cleaner_config.dat. Operations run trim -> flush -> file cache -> purge standby, so the standby purge sweeps up everything the earlier steps produce.

The end-of-run summary now reports percentages alongside megabytes and attributes the result to the operations that actually ran, and distinguishes "all sub-options off" and "no privilege" from "0 MB freed".

UI fixes:
  - Stats row moved above the box divider and shown on the settings screen too; the static duplicate is gone, leaving only the live row.
  - StopLiveStatsRow now waits for the painter to exit, and the ticker re-checks stop before painting. A stray paint could previously land on the settings screen and overwrite its first option row.
  - Removed the duplicate CPU/Memory box from the RAM step output.
  - Console input is flushed before "Press ENTER to exit", and that prompt now requires a real ENTER. ENTER presses made during a run were queued by Windows and closed the window before the summary could be read.
  - New syscalls resolve via LazyProc.Find() first, since LazyProc.Call panics on an unresolvable export.