### PR TITLE
Add multi-language support with in-app language picker (v2.4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: CI
+
+# Runs on every push and pull request. The point is that nobody - including a
+# first-time contributor sending a translation - can merge something that
+# fails to build, breaks a test, or quietly changes the console layout.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    # Quiesce calls the Windows API directly, so it can only build and test on
+    # Windows. Go 1.23 is the floor promised in the README; the matrix keeps
+    # that promise honest instead of assuming it.
+    name: Build and test (Go ${{ matrix.go }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.23', 'stable']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
+
+      # Catches a dependency added without go.sum being updated, and stops a
+      # future dependency from quietly raising the Go floor above 1.23.
+      - name: Verify go.mod and go.sum are tidy
+        shell: bash
+        run: |
+          cp go.mod go.mod.bak && cp go.sum go.sum.bak
+          go mod tidy
+          if ! diff -u go.mod.bak go.mod || ! diff -u go.sum.bak go.sum; then
+            echo "::error::go.mod/go.sum are not tidy - run 'go mod tidy' and commit the result"
+            exit 1
+          fi
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test -count=1 ./...
+
+  # gofmt is purely syntactic, so it does not need Windows. Running it on
+  # Linux also sidesteps Git for Windows checking the sources out with CRLF,
+  # which gofmt would report as a diff on every single file.
+  format:
+    name: gofmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files need gofmt:"
+            echo "$unformatted"
+            gofmt -d .
+            exit 1
+          fi
+
+  # Both shipped architectures must compile. Cross-compiling from Linux is
+  # enough to catch an arch-specific mistake without a second Windows runner.
+  crossbuild:
+    name: Cross-build ${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goarch: [amd64, '386']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+
+      - name: Build
+        env:
+          GOOS: windows
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -o /dev/null .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,17 @@ jobs:
 
       # Catches a dependency added without go.sum being updated, and stops a
       # future dependency from quietly raising the Go floor above 1.23.
+      #
+      # `git diff` is used rather than comparing file copies: Git for Windows
+      # checks these files out with CRLF, while `go mod tidy` rewrites them
+      # with LF, so a plain diff reports every single line as changed even
+      # when nothing actually differs. git normalises line endings before
+      # comparing, so it only reports real changes.
       - name: Verify go.mod and go.sum are tidy
         shell: bash
         run: |
-          cp go.mod go.mod.bak && cp go.sum go.sum.bak
           go mod tidy
-          if ! diff -u go.mod.bak go.mod || ! diff -u go.sum.bak go.sum; then
+          if ! git diff --exit-code -- go.mod go.sum; then
             echo "::error::go.mod/go.sum are not tidy - run 'go mod tidy' and commit the result"
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ qc.dat
 
 # Binaries
 *.exe
+*.exe~
 
 # IDE & OS clutter
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to Quiesce are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.4.0] - 2026-08-19
+
+### Added
+
+- **Multi-language support.** The UI now follows the Windows display
+  language, falling back to English for any language without a translation.
+- **Spanish translation** (`locales/active.es.toml`), the first language
+  besides English.
+- **In-app language picker.** Press `L` on the settings screen for a numbered
+  list of languages; the active one is ticked. Press the number to switch and
+  `E` to save.
+- **`LANGUAGE=` config override.** Add `LANGUAGE=en` or `LANGUAGE=es` to
+  `cleaner_config.dat` to force a language regardless of Windows settings.
+  The value is preserved when settings are saved.
+- **UTF-8 console output**, so accented characters render correctly instead
+  of as mojibake.
+- **Test suite** covering translation completeness, format-verb consistency,
+  menu alignment, config round-tripping, and language fallback.
+- **CI on every push and pull request**: build and test on Go 1.23 and
+  stable, `go vet`, `gofmt`, a `go mod tidy` check, and cross-builds for
+  both `amd64` and `386`.
+
+### Changed
+
+- Menu and summary columns are now measured at runtime instead of relying on
+  hand-typed trailing spaces, so the `ON`/`OFF` column stays aligned in any
+  language.
+- Translations live in `locales/*.toml` and are embedded into the binary.
+  Adding a language needs no code change - see [docs/TRANSLATING.md].
+
+### Fixed
+
+- Saving settings no longer erases a `LANGUAGE=` line from the config file.
+- The `[12] Deep Cleanup` summary row now lines up with every other row; it
+  was one column off in English and further off in longer languages.
+
+## [2.3.0] - 2026-08-16
+
+### Changed
+
+- Relicensed from QSAL v1.0 to GPL-3.0-or-later.
+
+### Added
+
+- Build identity baked into the binary: `qc --version` prints the version,
+  author, repository, license and the executable's own SHA-256, without
+  requiring Administrator.
+
+## [2.2.0]
+
+### Added
+
+- Opt-in aggressive RAM reclaim: system file cache flush and working-set
+  trimming, both OFF by default.
+
+### Removed
+
+- DISM from Deep Cleanup.
+
+[docs/TRANSLATING.md]: docs/TRANSLATING.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The value is preserved when settings are saved.
 - **UTF-8 console output**, so accented characters render correctly instead
   of as mojibake.
+- The console window title now shows the version, e.g. `Quiesce v2.4.0`.
 - **Test suite** covering translation completeness, format-verb consistency,
   menu alignment, config round-tripping, and language fallback.
 - **CI on every push and pull request**: build and test on Go 1.23 and
@@ -37,6 +38,13 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Clicking the console window no longer freezes Quiesce.** Windows enables
+  QuickEdit by default, so a click put the console into selection mode, which
+  blocks every write until Enter or Esc is pressed - the app appeared to hang
+  and could not print an explanation, because printing was what was blocked.
+  QuickEdit is now switched off at startup and restored on exit, so a
+  terminal you already had open is left as you found it. Mouse drag-select is
+  unavailable while Quiesce runs; right-click → Mark still works.
 - Saving settings no longer erases a `LANGUAGE=` line from the config file.
 - The `[12] Deep Cleanup` summary row now lines up with every other row; it
   was one column off in English and further off in longer languages.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,29 @@ Every step can be customized in the menu settings, and your choices are saved au
 - **Smart Service Handling**: Background Windows services (like Windows Update & Delivery Optimization) are safely stopped before cleaning their cache files and automatically restarted afterward.
 - **Safe by Default**: Risky options like emptying the Recycle Bin are disabled by default. Deep system cleanup automatically resets back to OFF after every run so it cannot repeat accidentally.
 - **Single File & Portable**: No installer required. Just run `qc.exe` anywhere.
+- **Speaks Your Language**: The interface follows your Windows display language, falling back to English. English and Spanish ship today; adding a language takes one file and no code.
+
+---
+
+## Language
+
+Quiesce reads your Windows display language at startup. To change it, press
+**F** for settings, then **L**, pick a language by number, and press **E** to
+save. Your choice is remembered.
+
+You can also set it by hand in `cleaner_config.dat` (next to `qc.exe`):
+
+```text
+LANGUAGE=es
+```
+
+| Code | Language |
+|---|---|
+| `en` | English |
+| `es` | Español |
+
+Want your language? It takes one file, no Go code — see
+[docs/TRANSLATING.md](docs/TRANSLATING.md). Pull requests welcome.
 
 ---
 
@@ -49,6 +72,7 @@ Launch **`qc.exe`** as Administrator:
 Settings Controls:
   W / S    Move selection Up / Down
   D / A    Toggle step ON / OFF
+  L        Choose language
   E        Save & return to main menu
 ```
 
@@ -82,7 +106,7 @@ The commit hash and build time are stamped in automatically from git. To set an
 explicit version string:
 
 ```bash
-go build -ldflags "-X main.Version=2.2.0" -o qc.exe
+go build -ldflags "-X main.Version=2.4.0" -o qc.exe
 ```
 
 ---

--- a/cleaner.go
+++ b/cleaner.go
@@ -32,16 +32,16 @@ import (
 )
 
 type StepResults struct {
-	TotalDeleted       int64
-	TotalFailed        int64
-	DnsFailed          bool
-	RecycleBinFailed   bool
-	RecycleBinBytes    uint64
-	RamFreedMB         int64
-	Ram                RamResult
-	DeepCleanupRan     bool
-	DeepCleanupFailed  bool
-	StepCounts         [12]int64
+	TotalDeleted      int64
+	TotalFailed       int64
+	DnsFailed         bool
+	RecycleBinFailed  bool
+	RecycleBinBytes   uint64
+	RamFreedMB        int64
+	Ram               RamResult
+	DeepCleanupRan    bool
+	DeepCleanupFailed bool
+	StepCounts        [12]int64
 }
 
 func stopService(name string) {
@@ -237,8 +237,8 @@ func RunCleaningPipeline(cfg *Config) (results StepResults) {
 	// so the summary can still be displayed.
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Printf("\n\x1b[31m[ERROR]\x1b[0m Cleaning pipeline crashed: %v\n", r)
-			fmt.Println("Partial results will be shown.")
+			fmt.Printf("\n\x1b[31m[ERROR]\x1b[0m %s\n", Tf("cleaner.crashed", r))
+			fmt.Println(T("cleaner.partial"))
 		}
 	}()
 
@@ -251,152 +251,152 @@ func RunCleaningPipeline(cfg *Config) (results StepResults) {
 	// [1/12] Windows Temp folder
 	fmt.Println()
 	if cfg.WinTemp == 1 {
-		TypeLine("[1/12] Cleaning Windows Temp folder...", 0)
+		StepHeader(1)
 		fmt.Println("+---------------------------------------+")
 		winTempDir := filepath.Join(systemRoot, "Temp")
 		cleanDirContents(winTempDir, true, &results, 1)
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[1/12] Windows Temp folder           - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(1)
 	}
 
 	// [2/12] User Temp folder
 	fmt.Println()
 	if cfg.UserTemp == 1 {
-		TypeLine("[2/12] Cleaning User Temp folder...", 0)
+		StepHeader(2)
 		fmt.Println("+---------------------------------------+")
 		cleanDirContents(userTemp, true, &results, 2)
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[2/12] User Temp folder              - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(2)
 	}
 
 	// [3/12] Prefetch folder
 	fmt.Println()
 	if cfg.Prefetch == 1 {
-		TypeLine("[3/12] Cleaning Prefetch folder...", 0)
+		StepHeader(3)
 		fmt.Println("+---------------------------------------+")
 		prefetchDir := filepath.Join(systemRoot, "Prefetch")
 		cleanDirContents(prefetchDir, true, &results, 3)
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[3/12] Prefetch folder               - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(3)
 	}
 
 	// [4/12] Windows Error Reports
 	fmt.Println()
 	if cfg.ErrorReports == 1 {
-		TypeLine("[4/12] Cleaning Windows Error Reports...", 0)
+		StepHeader(4)
 		fmt.Println("+---------------------------------------+")
 		werDir := filepath.Join(programData, "Microsoft", "Windows", "WER")
 		cleanDirRecursiveFiles(werDir, true, &results, 4)
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[4/12] Windows Error Reports         - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(4)
 	}
 
 	// [5/12] Delivery Optimization Cache
 	fmt.Println()
 	if cfg.DeliveryOpt == 1 {
-		TypeLine("[5/12] Cleaning Delivery Optimization Cache...", 0)
+		StepHeader(5)
 		fmt.Println("+---------------------------------------+")
 		stopService("DoSvc")
 		doDir := filepath.Join(systemRoot, "SoftwareDistribution", "DeliveryOptimization")
 		cleanDirRecursiveFiles(doDir, true, &results, 5)
 		startService("DoSvc")
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[5/12] Delivery Optimization Cache   - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(5)
 	}
 
 	// [6/12] Windows Update Cache
 	fmt.Println()
 	if cfg.WinUpdate == 1 {
-		TypeLine("[6/12] Cleaning Windows Update Cache...", 0)
+		StepHeader(6)
 		fmt.Println("+---------------------------------------+")
 		stopService("wuauserv")
 		wuDir := filepath.Join(systemRoot, "SoftwareDistribution", "Download")
 		cleanDirRecursiveFiles(wuDir, true, &results, 6)
 		startService("wuauserv")
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[6/12] Windows Update Cache          - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(6)
 	}
 
 	// [7/12] Windows Log Files
 	fmt.Println()
 	if cfg.LogFiles == 1 {
-		TypeLine("[7/12] Cleaning Windows Log Files...", 0)
+		StepHeader(7)
 		fmt.Println("+---------------------------------------+")
 		logsDir := filepath.Join(systemRoot, "Logs")
 		cleanDirRecursiveFiles(logsDir, true, &results, 7)
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[7/12] Windows Log Files             - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(7)
 	}
 
 	// [8/12] Windows Installer Temp
 	fmt.Println()
 	if cfg.InstallerTemp == 1 {
-		TypeLine("[8/12] Cleaning Windows Installer Temp...", 0)
+		StepHeader(8)
 		fmt.Println("+---------------------------------------+")
 		stopService("msiserver")
 		instDir := filepath.Join(systemRoot, "Installer", "$PatchCache$")
 		cleanDirRecursiveFiles(instDir, true, &results, 8)
 		startService("msiserver")
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[8/12] Windows Installer Temp        - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(8)
 	}
 
 	// [9/12] DNS Cache
 	fmt.Println()
 	if cfg.DnsFlush == 1 {
-		TypeLine("[9/12] Flushing DNS Cache...", 0)
+		StepHeader(9)
 		fmt.Println("+---------------------------------------+")
 		ok := FlushDNS()
 		if ok {
-			fmt.Println("\x1b[31m[OK]\x1b[0m DNS cache flushed")
+			fmt.Printf("\x1b[31m[OK]\x1b[0m %s\n", T("cleaner.dns_ok"))
 		} else {
-			fmt.Println("[SKIP] Could not flush DNS")
+			fmt.Println(T("cleaner.dns_fail"))
 			results.DnsFailed = true
 		}
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[9/12] DNS Cache                     - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(9)
 	}
 
 	// [10/12] RAM Optimization
 	fmt.Println()
 	if cfg.RamOptimize == 1 {
-		TypeLine("[10/12] Optimizing RAM...", 0)
+		StepHeader(10)
 		fmt.Println("+---------------------------------------+")
 		results.Ram = RunRamCleaner(cfg)
 		results.RamFreedMB = results.Ram.FreedMB
 	} else {
-		fmt.Println("[10/12] RAM Optimization             - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(10)
 	}
 
 	// [11/11] Recycle Bin (OFF by default - destructive/irreversible)
 	fmt.Println()
 	if cfg.RecycleBin == 1 {
-		TypeLine("[11/12] Emptying Recycle Bin...", 0)
+		StepHeader(11)
 		fmt.Println("+---------------------------------------+")
 		bytesFreed, ok := EmptyRecycleBin()
 		if ok {
 			results.RecycleBinBytes = bytesFreed
 			if bytesFreed > 0 {
-				fmt.Printf("\x1b[31m[OK]\x1b[0m Recycle Bin emptied - %s freed\n", FormatBytesHuman(bytesFreed))
+				fmt.Printf("\x1b[31m[OK]\x1b[0m %s\n", Tf("cleaner.bin_freed", FormatBytesHuman(bytesFreed)))
 			} else {
-				fmt.Println("\x1b[31m[OK]\x1b[0m Recycle Bin emptied - already empty")
+				fmt.Printf("\x1b[31m[OK]\x1b[0m %s\n", T("cleaner.bin_empty"))
 			}
 		} else {
-			fmt.Println("[SKIP] Could not empty Recycle Bin")
+			fmt.Println(T("cleaner.bin_fail"))
 			results.RecycleBinFailed = true
 		}
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 	} else {
-		fmt.Println("[11/12] Recycle Bin                  - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(11)
 	}
 
 	// [12/12] Deep Cleanup - AGGRESSIVE — one-time opt-in, always resets
@@ -407,7 +407,7 @@ func RunCleaningPipeline(cfg *Config) (results StepResults) {
 
 		// Configure registry for completely silent, maximum cleaning
 		if err := setupSagerun99(); err != nil {
-			fmt.Printf("\x1b[36m[WARN]\x1b[0m Could not setup registry for cleanmgr: %v\n", err)
+			fmt.Printf("\x1b[36m[WARN]\x1b[0m %s\n", Tf("cleaner.reg_fail", err))
 		}
 
 		// --- Command 1: cleanmgr.exe /sagerun:99 ---
@@ -415,17 +415,17 @@ func RunCleaningPipeline(cfg *Config) (results StepResults) {
 		// (dismhost.exe / cleanmgr.exe worker) and the parent exits
 		// immediately with success, so cmd.Run() alone proves nothing.
 		// We launch it, then poll for the worker process to disappear.
-		fmt.Println("  Running: cleanmgr.exe /sagerun:99")
+		fmt.Printf("  %s\n", T("cleaner.cleanmgr_run"))
 		cmd1 := exec.Command("cleanmgr.exe", "/sagerun:99")
 		cmd1.Stdout = os.Stdout
 		cmd1.Stderr = os.Stderr
 		if err := cmd1.Run(); err != nil {
-			fmt.Printf("  \x1b[36m[WARN]\x1b[0m cleanmgr.exe launch failed: %v\n", err)
+			fmt.Printf("  \x1b[36m[WARN]\x1b[0m %s\n", Tf("cleaner.cleanmgr_fail", err))
 			results.DeepCleanupFailed = true
 		} else {
 			// Wait for background cleanmgr worker to finish.
 			// Poll every 2 seconds for up to 5 minutes.
-			fmt.Println("  Waiting for cleanmgr background worker to finish...")
+			fmt.Printf("  %s\n", T("cleaner.cleanmgr_wait"))
 			cleanmgrDone := false
 			for i := 0; i < 150; i++ {
 				time.Sleep(2 * time.Second)
@@ -438,20 +438,20 @@ func RunCleaningPipeline(cfg *Config) (results StepResults) {
 				}
 			}
 			if cleanmgrDone {
-				fmt.Println("  \x1b[31m[OK]\x1b[0m cleanmgr.exe completed")
+				fmt.Printf("  \x1b[31m[OK]\x1b[0m %s\n", T("cleaner.cleanmgr_ok"))
 			} else {
-				fmt.Println("  \x1b[36m[WARN]\x1b[0m cleanmgr.exe timed out (may still be running)")
+				fmt.Printf("  \x1b[36m[WARN]\x1b[0m %s\n", T("cleaner.cleanmgr_time"))
 				results.DeepCleanupFailed = true
 			}
 		}
 
 		results.DeepCleanupRan = true
-		fmt.Println("Done!")
+		fmt.Println(T("common.done"))
 
 		// CRITICAL: always reset back to OFF after running
 		cfg.DeepCleanup = 0
 	} else {
-		fmt.Println("[12/12] Deep Cleanup - AGGRESSIVE    - \x1b[36mSKIPPED\x1b[0m")
+		StepSkipped(12)
 	}
 
 	return results

--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -46,6 +47,15 @@ type Config struct {
 	RamPurgeStandby    int // free the standby (cached) page list
 	RamFileCache       int // flush the kernel/system file cache working set
 	RamTrimWorkingSets int // page out every process's working set (aggressive)
+
+	// Language is the optional UI language override ("en", "es", ...). Empty
+	// means follow the Windows display language.
+	//
+	// It is read here purely so SaveConfig can write it back: the value that
+	// actually selects the language is read much earlier, by InitLanguage,
+	// before elevation. Without round-tripping it, saving from the settings
+	// screen would silently delete the user's LANGUAGE= line.
+	Language string
 }
 
 func DefaultConfig() *Config {
@@ -69,6 +79,22 @@ func DefaultConfig() *Config {
 	}
 }
 
+// ConfigFilePath returns the path to cleaner_config.dat alongside the running
+// executable, falling back to the working directory if the executable path
+// cannot be determined.
+//
+// This is resolved at startup rather than inside LoadConfig because the
+// language override is read from the same file before elevation, while
+// LoadConfig only runs after it.
+func ConfigFilePath() string {
+	exePath, err := os.Executable()
+	dir := "."
+	if err == nil {
+		dir = filepath.Dir(exePath)
+	}
+	return filepath.Join(dir, "cleaner_config.dat")
+}
+
 func LoadConfig(filePath string) (*Config, error) {
 	cfg := DefaultConfig()
 
@@ -77,7 +103,7 @@ func LoadConfig(filePath string) (*Config, error) {
 		if os.IsNotExist(err) {
 			errSave := SaveConfig(filePath, cfg)
 			if errSave == nil {
-				fmt.Println("\n  \x1b[97m[NOTE]\x1b[0m Config created: " + filePath)
+				fmt.Printf("\n  \x1b[97m[NOTE]\x1b[0m %s\n", Tf("common.config_made", filePath))
 			}
 			return cfg, nil
 		}
@@ -96,6 +122,14 @@ func LoadConfig(filePath string) (*Config, error) {
 			continue
 		}
 		key := strings.TrimSpace(parts[0])
+
+		// LANGUAGE is the one non-numeric setting, so it is handled before
+		// the Atoi below - which would otherwise reject it and skip the line.
+		if strings.EqualFold(key, "LANGUAGE") {
+			cfg.Language = strings.TrimSpace(parts[1])
+			continue
+		}
+
 		val, parseErr := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if parseErr != nil {
 			continue
@@ -157,6 +191,14 @@ func SaveConfig(filePath string, cfg *Config) error {
 		cfg.RamFileCache,
 		cfg.RamTrimWorkingSets,
 	)
+
+	// Preserve an explicit language override across saves. It is only written
+	// when the user actually set one, so a default config file stays free of
+	// a setting most people never touch.
+	if lang := strings.TrimSpace(cfg.Language); lang != "" {
+		content += fmt.Sprintf("LANGUAGE=%s\n", lang)
+	}
+
 	return os.WriteFile(filePath, []byte(content), 0644)
 }
 
@@ -233,5 +275,3 @@ func (c *Config) SetVal(index int, val int) {
 		c.RamTrimWorkingSets = val
 	}
 }
-
-

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLanguageSurvivesSave is the regression test for a data-loss bug:
+// SaveConfig rewrites the whole file, so before LANGUAGE was round-tripped,
+// pressing E on the settings screen silently deleted the user's language
+// override and the app reverted to the Windows display language.
+func TestLanguageSurvivesSave(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cleaner_config.dat")
+	if err := os.WriteFile(path, []byte("WIN_TEMP=1\nLANGUAGE=es\n"), 0644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Language != "es" {
+		t.Fatalf("LoadConfig did not read LANGUAGE: got %q, want %q", cfg.Language, "es")
+	}
+
+	if err := SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+
+	if got := readLanguageOverride(path); got != "es" {
+		t.Errorf("LANGUAGE lost across save: readLanguageOverride = %q, want %q", got, "es")
+	}
+
+	reloaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("reloading: %v", err)
+	}
+	if reloaded.Language != "es" {
+		t.Errorf("reloaded language = %q, want %q", reloaded.Language, "es")
+	}
+}
+
+// TestNoLanguageLineWhenUnset keeps the default config file clean: a user who
+// never chose a language should not find a LANGUAGE= line in their config.
+func TestNoLanguageLineWhenUnset(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cleaner_config.dat")
+	if err := SaveConfig(path, DefaultConfig()); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading back: %v", err)
+	}
+	if strings.Contains(string(data), "LANGUAGE") {
+		t.Errorf("default config should not contain a LANGUAGE line:\n%s", data)
+	}
+}
+
+// TestLanguageLineDoesNotBreakNumericSettings guards the parser change: the
+// non-numeric LANGUAGE value must not make LoadConfig skip or misread the
+// numeric settings around it.
+func TestLanguageLineDoesNotBreakNumericSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cleaner_config.dat")
+	content := "WIN_TEMP=0\nLANGUAGE=es\nRECYCLE_BIN=1\nRAM_FILE_CACHE=1\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.WinTemp != 0 {
+		t.Errorf("WinTemp = %d, want 0", cfg.WinTemp)
+	}
+	if cfg.RecycleBin != 1 {
+		t.Errorf("RecycleBin = %d, want 1 (setting after LANGUAGE was skipped)", cfg.RecycleBin)
+	}
+	if cfg.RamFileCache != 1 {
+		t.Errorf("RamFileCache = %d, want 1", cfg.RamFileCache)
+	}
+}
+
+// TestDeepCleanupIsNeverPersisted locks in the existing safety rule: the
+// destructive step must always start OFF, never resurrected from a config
+// file, whether or not that file was written by this version.
+func TestDeepCleanupIsNeverPersisted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cleaner_config.dat")
+
+	cfg := DefaultConfig()
+	cfg.DeepCleanup = 1
+	if err := SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	if data, err := os.ReadFile(path); err == nil && strings.Contains(string(data), "DEEP") {
+		t.Errorf("Deep Cleanup was written to disk:\n%s", data)
+	}
+
+	if err := os.WriteFile(path, []byte("DEEP_CLEANUP=1\n"), 0644); err != nil {
+		t.Fatalf("writing fixture: %v", err)
+	}
+	reloaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if reloaded.DeepCleanup != 0 {
+		t.Errorf("DeepCleanup = %d, want 0 - it must never load from disk", reloaded.DeepCleanup)
+	}
+}
+
+// TestConfigRoundTripsEveryToggle checks that each of the 15 persisted
+// settings survives a save/load cycle, so a future edit to the format string
+// cannot silently drop one.
+func TestConfigRoundTripsEveryToggle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cleaner_config.dat")
+
+	indices := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 101, 102, 103, 104}
+
+	cfg := DefaultConfig()
+	// Invert every toggle so the test cannot pass on defaults alone.
+	for _, i := range indices {
+		cfg.SetVal(i, 1-cfg.GetVal(i))
+	}
+	want := map[int]int{}
+	for _, i := range indices {
+		want[i] = cfg.GetVal(i)
+	}
+
+	if err := SaveConfig(path, cfg); err != nil {
+		t.Fatalf("SaveConfig: %v", err)
+	}
+	got, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	for _, i := range indices {
+		if got.GetVal(i) != want[i] {
+			t.Errorf("setting %d = %d after round trip, want %d", i, got.GetVal(i), want[i])
+		}
+	}
+}

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -1,0 +1,100 @@
+# Translating Quiesce
+
+Quiesce ships English and Spanish. Adding a language takes one file and no
+Go code.
+
+## How the language is chosen
+
+1. Quiesce reads the Windows display language at startup.
+2. If a `LANGUAGE=` line exists in `cleaner_config.dat`, it wins.
+3. Anything with no translation falls back to English.
+
+Users change it in the app: **F** for settings, then **L**, pick by number,
+then **E** to save. That writes the `LANGUAGE=` line for them. It can also be
+set by hand in `cleaner_config.dat`, next to `qc.exe`:
+
+```
+LANGUAGE=es
+```
+
+## Adding a language
+
+1. Copy `locales/active.en.toml` to `locales/active.<code>.toml`, where
+   `<code>` is the two-letter [ISO 639-1] code - `fr`, `de`, `pt`, `ar`.
+2. Translate the value on the right of each `=`. Leave the key on the left
+   alone.
+3. Add your language's own name to `languageNames` in `lang.go`, so it
+   appears in the in-app picker:
+
+   ```go
+   var languageNames = map[string]string{
+       "en": "English",
+       "es": "Español",
+       "fr": "Français", // <- yours
+   }
+   ```
+
+   Write it the way speakers of that language write it, not translated into
+   English - someone looking for their language needs to recognise it.
+4. Add the language to `primaryLangCode` in `lang.go` so Windows auto-detect
+   finds it. The [Windows LANGID list] gives the number; use the low 10 bits.
+5. Run the tests: `go test ./...`
+6. Build: `go build -o qc.exe`
+
+The file is embedded into the binary automatically - there is nothing to
+register and no build step to run.
+
+## Rules
+
+**Keep the format verbs.** `%s`, `%d`, `%.1f` are placeholders the program
+fills in. Keep every one, and keep them in the same order unless your
+language genuinely needs a different order.
+
+```toml
+# English
+"summary.total" = "Total items cleaned : %d"
+
+# Correct
+"summary.total" = "Elementos limpiados : %d"
+
+# Wrong - the number has nowhere to go
+"summary.total" = "Elementos limpiados"
+```
+
+`%%` is a literal percent sign, not a placeholder.
+
+**Do not add trailing spaces.** Column alignment is calculated while the
+program runs. Typed spaces would be added on top of it and push the column
+out of line.
+
+**Leave Windows terms in English.** Windows itself does not translate
+`Prefetch`, `DNS`, `RAM`, `Temp`, `cleanmgr` or `NTSTATUS`. Translating them
+makes it harder for someone to match Quiesce's output against what Windows
+shows them.
+
+**Write accents properly.** The console is switched to UTF-8, so `á`, `ñ`
+and `¿` display correctly. Never strip accents to work around a display
+problem - report it instead.
+
+**Keep it short.** This is a console UI. A label two or three words longer
+than the English will still align, but it makes the screen wide.
+
+## What the tests check
+
+`go test ./...` fails if:
+
+- a key is missing from your file, or has one English does not have
+- your format verbs do not match English
+- a value has trailing whitespace
+- any menu or summary column stops lining up in your language
+
+If those pass, your translation is safe to merge.
+
+## Submitting
+
+Open a pull request with your `locales/active.<code>.toml` and the two
+one-line additions to `lang.go` (`languageNames` and `primaryLangCode`).
+CI runs the checks above automatically.
+
+[ISO 639-1]: https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+[Windows LANGID list]: https://learn.microsoft.com/en-us/windows/win32/intl/language-identifier-constants-and-strings

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,11 @@ module quiesce
 
 go 1.23.0
 
-toolchain go1.23.1
-
-require golang.org/x/sys v0.33.0
+require (
+	github.com/BurntSushi/toml v1.6.0
+	github.com/nicksnyder/go-i18n/v2 v2.4.0
+	golang.org/x/sys v0.33.0
+	golang.org/x/text v0.21.0
+)
 
 replace golang.org/x/sys => github.com/golang/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,10 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/golang/sys v0.33.0 h1:V0uv1VUsIZQbxIZrI0lWWPPltbnn8rwQJvVHybjlPU4=
 github.com/golang/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+github.com/nicksnyder/go-i18n/v2 v2.4.0 h1:3IcvPOAvnCKwNm0TB0dLDTuawWEj+ax/RERNC+diLMM=
+github.com/nicksnyder/go-i18n/v2 v2.4.0/go.mod h1:nxYSZE9M0bf3Y70gPQjN9ha7XNHX7gMc814+6wVyEI4=
+golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
+golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/lang.go
+++ b/lang.go
@@ -1,0 +1,256 @@
+// Quiesce - Windows system cleaner and RAM optimizer.
+// Copyright (C) 2026 SibtainOcn <https://github.com/SibtainOcn/Quiesce>
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <https://www.gnu.org/licenses/>.
+
+package main
+
+// Localization for the Quiesce console UI, built on nicksnyder/go-i18n (MIT).
+//
+// Translations live in locales/active.<code>.toml and are embedded into the
+// binary at build time, so qc.exe stays a single portable file with no
+// sidecar files to ship or lose.
+//
+// Adding a language requires no code change at all: drop
+// locales/active.<code>.toml next to the others and rebuild. The whole
+// directory is embedded and parsed, and the language is matched against the
+// Windows display language automatically.
+//
+// Every lookup falls back to English, and finally to the key itself, so a
+// missing or half-finished translation degrades per-string instead of
+// printing blank lines on a screen the user is about to run as Administrator.
+
+import (
+	"bufio"
+	"embed"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"golang.org/x/sys/windows"
+	"golang.org/x/text/language"
+)
+
+//go:embed locales/*.toml
+var localeFS embed.FS
+
+var (
+	modkernel32Lang              = windows.NewLazySystemDLL("kernel32.dll")
+	procGetUserDefaultUILanguage = modkernel32Lang.NewProc("GetUserDefaultUILanguage")
+)
+
+var (
+	bundle     *i18n.Bundle
+	localizer  *i18n.Localizer
+	activeCode = "en"
+)
+
+// init builds the message bundle from the embedded locale files. It runs
+// before main(), so T() is safe to call from anywhere - including the very
+// first line printed by --version or the elevation prompt.
+//
+// Parse failures are skipped rather than fatal: one malformed community
+// translation file must not stop the app from starting in English.
+func init() {
+	bundle = i18n.NewBundle(language.English)
+	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
+
+	entries, err := localeFS.ReadDir("locales")
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".toml") {
+				continue
+			}
+			data, readErr := localeFS.ReadFile("locales/" + e.Name())
+			if readErr != nil {
+				continue
+			}
+			// The language is inferred from the filename, e.g.
+			// "active.es.toml" registers Spanish.
+			_, _ = bundle.ParseMessageFileBytes(data, e.Name())
+		}
+	}
+
+	localizer = i18n.NewLocalizer(bundle, "en")
+}
+
+// T returns the translated string for key. go-i18n resolves the active
+// language first and English second; if the key exists in neither, the key
+// itself is returned so a typo is visible on screen rather than silent.
+func T(key string) string {
+	s, err := localizer.Localize(&i18n.LocalizeConfig{MessageID: key})
+	if err != nil || s == "" {
+		return key
+	}
+	return s
+}
+
+// Tf is T followed by Sprintf. The format verbs live inside the translated
+// string so translators can reorder them to suit their language.
+func Tf(key string, a ...interface{}) string {
+	return fmt.Sprintf(T(key), a...)
+}
+
+// ActiveLanguage reports the language code currently in use.
+func ActiveLanguage() string { return activeCode }
+
+// languageNames holds each language's name written in that language itself.
+//
+// Language menus are never translated: a Spanish speaker looking at an
+// English UI needs to find "Español", not "Spanish". Adding a language means
+// adding one entry here alongside its locale file.
+var languageNames = map[string]string{
+	"en": "English",
+	"es": "Español",
+}
+
+// AvailableLanguages lists every language embedded in this build, sorted so
+// the picker and --version always show them in the same order.
+func AvailableLanguages() []string {
+	tags := bundle.LanguageTags()
+	codes := make([]string, 0, len(tags))
+	for _, t := range tags {
+		codes = append(codes, t.String())
+	}
+	sort.Strings(codes)
+	return codes
+}
+
+// LanguageDisplayName returns a language's own name for the picker, falling
+// back to the bare code so a locale file added without a name entry still
+// shows up as something selectable rather than a blank row.
+func LanguageDisplayName(code string) string {
+	if name, ok := languageNames[strings.ToLower(code)]; ok {
+		return name
+	}
+	return code
+}
+
+// SetLanguage switches the active language, always keeping English as the
+// fallback. An unknown code is not an error: go-i18n simply resolves
+// everything through English, which is the behaviour we want for a bad
+// LANGUAGE= line - the app runs, in English, instead of refusing to start.
+func SetLanguage(code string) {
+	code = strings.ToLower(strings.TrimSpace(code))
+	if code == "" {
+		code = "en"
+	}
+	localizer = i18n.NewLocalizer(bundle, code, "en")
+	activeCode = code
+}
+
+// InitLanguage picks the UI language: the Windows display language by
+// default, overridden by a LANGUAGE= line in the config file if present.
+//
+// This runs before anything is printed - including --version/--help and the
+// elevation prompt - so it reads the override itself rather than waiting for
+// LoadConfig, which only happens after elevation.
+func InitLanguage(configPath string) {
+	code := detectSystemLanguage()
+	if override := readLanguageOverride(configPath); override != "" {
+		code = override
+	}
+	SetLanguage(code)
+}
+
+// detectSystemLanguage maps the Windows display language to a language code.
+//
+// GetUserDefaultUILanguage returns a LANGID whose low 10 bits identify the
+// primary language. Only the primary language is used, so es-ES and es-MX
+// both resolve to "es" - the UI has no region-specific wording, and matching
+// on the full LANGID would leave most Spanish installs on English.
+func detectSystemLanguage() string {
+	if procGetUserDefaultUILanguage.Find() != nil {
+		return "en"
+	}
+	r1, _, _ := procGetUserDefaultUILanguage.Call()
+	return primaryLangCode(uint16(r1))
+}
+
+// primaryLangCode converts a Windows LANGID to an ISO 639-1 code. Codes
+// without a locale file resolve through English at lookup time, so this list
+// only needs a case per language actually shipped.
+func primaryLangCode(langID uint16) string {
+	switch langID & 0x3FF {
+	case 0x09:
+		return "en"
+	case 0x0A:
+		return "es"
+	default:
+		return "en"
+	}
+}
+
+// readLanguageOverride scans the config file for a LANGUAGE= line. It is
+// deliberately standalone and failure-tolerant: the file may not exist yet on
+// first run, and this is called before LoadConfig.
+func readLanguageOverride(configPath string) string {
+	if configPath == "" {
+		return ""
+	}
+	file, err := os.Open(configPath)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 && strings.EqualFold(strings.TrimSpace(parts[0]), "LANGUAGE") {
+			return strings.TrimSpace(parts[1])
+		}
+	}
+	return ""
+}
+
+// --- Layout helpers ------------------------------------------------------
+//
+// The console UI aligns its ON/OFF column by padding labels to a fixed width.
+// That padding used to be typed into the English strings as trailing spaces,
+// which breaks the moment a label is translated - Spanish labels run 20-30%
+// longer than their English source.
+//
+// So the width is measured at runtime from the strings actually in use, in
+// RUNES rather than bytes: "Optimización" is 12 characters but 13 bytes in
+// UTF-8, and padding by byte length would misalign every accented label.
+
+// padRight pads s with spaces to width w (measured in runes). Labels longer
+// than w are returned unchanged rather than truncated - a clipped label is
+// worse than a nudged column.
+func padRight(s string, w int) string {
+	if n := w - len([]rune(s)); n > 0 {
+		return s + strings.Repeat(" ", n)
+	}
+	return s
+}
+
+// maxKeyWidth returns the rune width of the longest translated value among
+// the given keys, in the active language.
+func maxKeyWidth(keys ...string) int {
+	w := 0
+	for _, k := range keys {
+		if n := len([]rune(T(k))); n > w {
+			w = n
+		}
+	}
+	return w
+}

--- a/lang_test.go
+++ b/lang_test.go
@@ -1,0 +1,428 @@
+package main
+
+// Tests for the localization layer.
+//
+// These exist to catch the three ways a translation breaks a release, none of
+// which the compiler can see:
+//
+//  1. A key is used in Go code but missing from a locale file, so the raw key
+//     ("summary.total") is printed to the user.
+//  2. A translator changes the format verbs - drops a %s, or writes %d where
+//     the code passes a string - so Printf emits "%!d(string=...)" garbage.
+//  3. A translated label is longer than its English source, breaking the
+//     ON/OFF column that the menu relies on.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+// defaultLang is the source language every other file is compared against.
+const defaultLang = "en"
+
+// ansiRe matches the ANSI color escapes used by the UI, so tests can measure
+// the visible width of a label rather than its byte length.
+var ansiRe = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// verbRe matches a printf verb. "%%" is excluded by the alternation order:
+// it is matched first and then discarded, so it never counts as a verb.
+var verbRe = regexp.MustCompile(`%%|%[-+ #0]*[0-9]*(?:\.[0-9]+)?[a-zA-Z]`)
+
+// staticKeyRe finds T("...") and Tf("...") calls in the Go sources.
+var staticKeyRe = regexp.MustCompile(`\bTf?\("([^"]+)"`)
+
+// visibleWidth is the rune count of s with color escapes removed.
+func visibleWidth(s string) int {
+	return len([]rune(ansiRe.ReplaceAllString(s, "")))
+}
+
+// verbs returns the printf verbs in s, in order, ignoring "%%".
+func verbs(s string) []string {
+	out := []string{}
+	for _, m := range verbRe.FindAllString(s, -1) {
+		if m != "%%" {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// loadLocale reads one locale file straight from disk (not the embedded copy)
+// so a test failure points at the file a translator actually edits.
+func loadLocale(t *testing.T, code string) map[string]string {
+	t.Helper()
+	path := filepath.Join("locales", "active."+code+".toml")
+	raw := map[string]interface{}{}
+	if _, err := toml.DecodeFile(path, &raw); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	out := map[string]string{}
+	for k, v := range raw {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("%s: key %q is %T, want a string", path, k, v)
+		}
+		out[k] = s
+	}
+	return out
+}
+
+// localeCodes lists every language file present in locales/.
+func localeCodes(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir("locales")
+	if err != nil {
+		t.Fatalf("reading locales/: %v", err)
+	}
+	var codes []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "active.") || !strings.HasSuffix(name, ".toml") {
+			continue
+		}
+		codes = append(codes, strings.TrimSuffix(strings.TrimPrefix(name, "active."), ".toml"))
+	}
+	sort.Strings(codes)
+	if len(codes) == 0 {
+		t.Fatal("no locale files found in locales/")
+	}
+	return codes
+}
+
+// usedKeys collects every message key the program can ask for: the literal
+// T("...")/Tf("...") calls found in the sources, plus the per-step keys that
+// are built at runtime with Sprintf and so cannot be found by scanning.
+func usedKeys(t *testing.T) []string {
+	t.Helper()
+
+	set := map[string]bool{}
+
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("globbing sources: %v", err)
+	}
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		for _, m := range staticKeyRe.FindAllStringSubmatch(string(src), -1) {
+			set[m[1]] = true
+		}
+	}
+
+	// Keys assembled at runtime, e.g. T(fmt.Sprintf("step.%d.name", i)).
+	for i := 1; i <= 12; i++ {
+		set[fmt.Sprintf("step.%d.name", i)] = true
+		set[fmt.Sprintf("step.%d.action", i)] = true
+		set[fmt.Sprintf("step.%d.short", i)] = true
+	}
+	for _, i := range ramSubOptions {
+		set[fmt.Sprintf("sub.%d.name", i)] = true
+		set[fmt.Sprintf("sub.%d.note", i)] = true
+	}
+
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestEveryUsedKeyExistsInEnglish is the safety net for a typo'd key: English
+// is the final fallback, so a key missing here is printed raw to the user.
+func TestEveryUsedKeyExistsInEnglish(t *testing.T) {
+	en := loadLocale(t, defaultLang)
+	for _, k := range usedKeys(t) {
+		if _, ok := en[k]; !ok {
+			t.Errorf("key %q is used in code but missing from locales/active.en.toml", k)
+		}
+	}
+}
+
+// TestNoUnusedKeys catches the opposite drift: a key left in the locale files
+// after the code that printed it was removed. Translators should not be asked
+// to translate strings nothing displays.
+func TestNoUnusedKeys(t *testing.T) {
+	used := map[string]bool{}
+	for _, k := range usedKeys(t) {
+		used[k] = true
+	}
+	for k := range loadLocale(t, defaultLang) {
+		if !used[k] {
+			t.Errorf("key %q is in locales/active.en.toml but never used in code", k)
+		}
+	}
+}
+
+// TestTranslationsAreComplete requires every non-default language to cover
+// every English key. Missing keys still fall back to English at runtime, so
+// this is a completeness check, not a crash check - but a half-translated
+// screen is a bug worth failing CI over.
+func TestTranslationsAreComplete(t *testing.T) {
+	en := loadLocale(t, defaultLang)
+	for _, code := range localeCodes(t) {
+		if code == defaultLang {
+			continue
+		}
+		other := loadLocale(t, code)
+		for k := range en {
+			if v, ok := other[k]; !ok || strings.TrimSpace(v) == "" {
+				t.Errorf("locales/active.%s.toml is missing key %q", code, k)
+			}
+		}
+		for k := range other {
+			if _, ok := en[k]; !ok {
+				t.Errorf("locales/active.%s.toml has key %q that English does not", code, k)
+			}
+		}
+	}
+}
+
+// TestFormatVerbsMatchEnglish is the one that prevents a runtime mess: if a
+// translator drops a %s or swaps %d for %s, Printf produces "%!d(string=...)"
+// on screen. The verbs must match English exactly, in order.
+func TestFormatVerbsMatchEnglish(t *testing.T) {
+	en := loadLocale(t, defaultLang)
+	for _, code := range localeCodes(t) {
+		if code == defaultLang {
+			continue
+		}
+		other := loadLocale(t, code)
+		for k, enVal := range en {
+			otherVal, ok := other[k]
+			if !ok {
+				continue // reported by TestTranslationsAreComplete
+			}
+			want, got := verbs(enVal), verbs(otherVal)
+			if strings.Join(want, ",") != strings.Join(got, ",") {
+				t.Errorf("locales/active.%s.toml key %q has verbs %v, English has %v",
+					code, k, got, want)
+			}
+		}
+	}
+}
+
+// TestMenuColumnsAlign is the regression test for the bug this change fixes:
+// labels used to carry hand-typed trailing spaces, so any translation longer
+// than its English source pushed the ON/OFF column out of line. Every label
+// in a group must end up the same visible width, in every language.
+func TestMenuColumnsAlign(t *testing.T) {
+	original := ActiveLanguage()
+	defer SetLanguage(original)
+
+	for _, code := range localeCodes(t) {
+		SetLanguage(code)
+
+		width := -1
+		for i := 1; i <= 12; i++ {
+			w := visibleWidth(GetCfgDispName(i))
+			if width == -1 {
+				width = w
+			}
+			if w != width {
+				t.Errorf("[%s] step %d label is %d wide, expected %d - ON/OFF column would not line up",
+					code, i, w, width)
+			}
+		}
+
+		subWidth := -1
+		for _, i := range ramSubOptions {
+			w := visibleWidth(GetCfgDispName(i))
+			if subWidth == -1 {
+				subWidth = w
+			}
+			if w != subWidth {
+				t.Errorf("[%s] sub-option %d label is %d wide, expected %d",
+					code, i, w, subWidth)
+			}
+		}
+	}
+}
+
+// TestNoTrailingSpacesInLocales enforces the rule the locale files state:
+// padding is computed at runtime, so a translator adding trailing spaces
+// would silently double the padding.
+func TestNoTrailingSpacesInLocales(t *testing.T) {
+	for _, code := range localeCodes(t) {
+		for k, v := range loadLocale(t, code) {
+			if v != strings.TrimRight(v, " \t") {
+				t.Errorf("locales/active.%s.toml key %q has trailing whitespace", code, k)
+			}
+		}
+	}
+}
+
+// TestUnknownLanguageFallsBackToEnglish covers a bad LANGUAGE= line in the
+// config: the app must run in English rather than print raw keys or crash.
+func TestUnknownLanguageFallsBackToEnglish(t *testing.T) {
+	original := ActiveLanguage()
+	defer SetLanguage(original)
+
+	SetLanguage(defaultLang)
+	want := T("summary.title")
+
+	for _, bad := range []string{"zz", "", "not-a-language", "  "} {
+		SetLanguage(bad)
+		if got := T("summary.title"); got != want {
+			t.Errorf("SetLanguage(%q): got %q, want English %q", bad, got, want)
+		}
+	}
+}
+
+// TestMissingKeyReturnsKey documents the last-resort behaviour: an unknown key
+// shows as itself, which is visible in testing rather than silently blank.
+func TestMissingKeyReturnsKey(t *testing.T) {
+	const key = "this.key.does.not.exist"
+	if got := T(key); got != key {
+		t.Errorf("T(%q) = %q, want the key itself", key, got)
+	}
+}
+
+// TestSpanishIsActuallyTranslated guards against a locale file that exists but
+// merely copies English - which would pass every other test here.
+func TestSpanishIsActuallyTranslated(t *testing.T) {
+	original := ActiveLanguage()
+	defer SetLanguage(original)
+
+	SetLanguage("es")
+	for _, k := range []string{"menu.will_clean", "summary.title", "settings.title", "common.done"} {
+		SetLanguage(defaultLang)
+		en := T(k)
+		SetLanguage("es")
+		if es := T(k); es == en {
+			t.Errorf("key %q is identical in English and Spanish (%q)", k, es)
+		}
+	}
+}
+
+// TestLanguageOverrideParsing covers the LANGUAGE= line read from the config
+// before elevation, including the cases a user is likely to type.
+func TestLanguageOverrideParsing(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		name, content, want string
+	}{
+		{"plain", "WIN_TEMP=1\nLANGUAGE=es\n", "es"},
+		{"spaced", "LANGUAGE =  es  \n", "es"},
+		{"lowercase key", "language=es\n", "es"},
+		{"absent", "WIN_TEMP=1\n", ""},
+		{"commented out", "# LANGUAGE=es\n", ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(dir, c.name+".dat")
+			if err := os.WriteFile(path, []byte(c.content), 0644); err != nil {
+				t.Fatalf("writing fixture: %v", err)
+			}
+			if got := readLanguageOverride(path); got != c.want {
+				t.Errorf("readLanguageOverride = %q, want %q", got, c.want)
+			}
+		})
+	}
+
+	if got := readLanguageOverride(filepath.Join(dir, "does-not-exist.dat")); got != "" {
+		t.Errorf("missing file: got %q, want empty", got)
+	}
+}
+
+// TestPrimaryLangCode checks the LANGID mapping, including sub-languages:
+// es-ES (0x0C0A) and es-MX (0x080A) must both resolve to Spanish, or most
+// Spanish installs would silently stay on English.
+func TestPrimaryLangCode(t *testing.T) {
+	cases := map[uint16]string{
+		0x0409: "en", // en-US
+		0x0809: "en", // en-GB
+		0x0C0A: "es", // es-ES
+		0x080A: "es", // es-MX
+		0x2C0A: "es", // es-AR
+		0x040C: "en", // fr-FR - no locale file, falls back
+	}
+	for langID, want := range cases {
+		if got := primaryLangCode(langID); got != want {
+			t.Errorf("primaryLangCode(0x%04X) = %q, want %q", langID, got, want)
+		}
+	}
+}
+
+// TestEveryLanguageHasADisplayName keeps the picker honest: a locale file
+// added without an entry in languageNames would show up as a bare code like
+// "fr" instead of "Français".
+func TestEveryLanguageHasADisplayName(t *testing.T) {
+	for _, code := range localeCodes(t) {
+		name := LanguageDisplayName(code)
+		if name == code {
+			t.Errorf("language %q has no entry in languageNames in lang.go", code)
+		}
+		if strings.TrimSpace(name) == "" {
+			t.Errorf("language %q has an empty display name", code)
+		}
+	}
+}
+
+// TestAvailableLanguagesMatchesLocaleFiles ensures the picker offers exactly
+// the languages that were embedded - no more, no fewer.
+func TestAvailableLanguagesMatchesLocaleFiles(t *testing.T) {
+	want := strings.Join(localeCodes(t), ",")
+	if got := strings.Join(AvailableLanguages(), ","); got != want {
+		t.Errorf("AvailableLanguages() = %q, want %q", got, want)
+	}
+}
+
+// TestKeyLineArgumentCounts pins the number of format verbs on the strings
+// the UI formats with a hard-coded argument list. Adding a key to the
+// settings line without updating the Tf call would print "%!s(MISSING)" or
+// "%!(EXTRA string=...)" across the top of the screen.
+func TestKeyLineArgumentCounts(t *testing.T) {
+	// key -> number of arguments the call site passes.
+	want := map[string]int{
+		"settings.keys":      12, // W, S, A, D, L, E - two color args each
+		"settings.save_hint": 2,
+		"language.keys":      4,
+		"language.save_hint": 2,
+		"menu.hint":          4,
+	}
+
+	for _, code := range localeCodes(t) {
+		loc := loadLocale(t, code)
+		for key, n := range want {
+			v, ok := loc[key]
+			if !ok {
+				continue // reported elsewhere
+			}
+			if got := len(verbs(v)); got != n {
+				t.Errorf("locales/active.%s.toml key %q has %d verbs, call site passes %d args",
+					code, key, got, n)
+			}
+		}
+	}
+}
+
+// TestPadRightCountsRunesNotBytes is the accent trap: "Optimización" is 12
+// characters but 13 bytes, so byte-based padding would misalign every
+// accented label by one column.
+func TestPadRightCountsRunesNotBytes(t *testing.T) {
+	const s = "Optimización"
+	if len(s) == len([]rune(s)) {
+		t.Fatal("fixture is not multi-byte; test would prove nothing")
+	}
+	if got := visibleWidth(padRight(s, 20)); got != 20 {
+		t.Errorf("padRight(%q, 20) is %d runes wide, want 20", s, got)
+	}
+	if got := padRight("already too long for this", 5); got != "already too long for this" {
+		t.Errorf("padRight truncated a long label: %q", got)
+	}
+}

--- a/locales/active.en.toml
+++ b/locales/active.en.toml
@@ -1,0 +1,195 @@
+# Quiesce - English (source language)
+#
+# This is the source translation and the fallback for every other language.
+# Any key missing from another file resolves here, so this file must stay
+# complete.
+#
+# To add a language: copy this file to active.<code>.toml (for example
+# active.fr.toml), translate every value, and rebuild. The file is embedded
+# into the binary automatically - no code changes are needed.
+#
+# Rules for translators:
+#   - Never change the key on the left of the "=".
+#   - Keep every %s / %d / %.1f / %% verb, in the same order, unless your
+#     language genuinely needs a different word order.
+#   - Windows technical terms (Prefetch, DNS, RAM, Temp, cleanmgr, NTSTATUS)
+#     stay in English on purpose - Windows itself does not translate them.
+#   - Do not pad values with trailing spaces. Column alignment is computed at
+#     runtime; typed spaces would double up.
+
+# --- Cleaning steps: menu label / progress header / summary label ---
+"step.1.name" = "Windows Temp folder"
+"step.1.action" = "Cleaning Windows Temp folder..."
+"step.1.short" = "Windows Temp"
+
+"step.2.name" = "User Temp folder"
+"step.2.action" = "Cleaning User Temp folder..."
+"step.2.short" = "User Temp"
+
+"step.3.name" = "Prefetch folder"
+"step.3.action" = "Cleaning Prefetch folder..."
+"step.3.short" = "Prefetch"
+
+"step.4.name" = "Windows Error Reports"
+"step.4.action" = "Cleaning Windows Error Reports..."
+"step.4.short" = "Error Reports"
+
+"step.5.name" = "Delivery Optimization"
+"step.5.action" = "Cleaning Delivery Optimization Cache..."
+"step.5.short" = "Delivery Optimization"
+
+"step.6.name" = "Windows Update Cache"
+"step.6.action" = "Cleaning Windows Update Cache..."
+"step.6.short" = "Windows Update Cache"
+
+"step.7.name" = "Windows Log Files"
+"step.7.action" = "Cleaning Windows Log Files..."
+"step.7.short" = "Windows Log Files"
+
+"step.8.name" = "Windows Installer Temp"
+"step.8.action" = "Cleaning Windows Installer Temp..."
+"step.8.short" = "Installer Temp"
+
+"step.9.name" = "DNS Cache Flush"
+"step.9.action" = "Flushing DNS Cache..."
+"step.9.short" = "DNS Cache"
+
+"step.10.name" = "RAM Optimization"
+"step.10.action" = "Optimizing RAM..."
+"step.10.short" = "RAM Optimization"
+
+"step.11.name" = "Empty Recycle Bin"
+"step.11.action" = "Emptying Recycle Bin..."
+"step.11.short" = "Recycle Bin"
+
+"step.12.name" = "Deep Cleanup"
+"step.12.action" = "Deep Cleanup - AGGRESSIVE..."
+"step.12.short" = "Deep Cleanup"
+"step.12.tag" = "RUN ONCE"
+
+# --- RAM Optimization sub-options: label and parenthetical note ---
+"sub.101.name" = "Flush modified list"
+"sub.101.note" = "dirty pages to disk"
+"sub.102.name" = "Purge standby list"
+"sub.102.note" = "frees cached memory"
+"sub.103.name" = "System file cache"
+"sub.103.note" = "kernel disk cache"
+"sub.104.name" = "Trim working sets"
+"sub.104.note" = "app memory, harsh"
+
+# --- Main menu ---
+"menu.will_clean" = "This will clean:"
+"menu.hint" = "Press %sENTER%s to Run  |  Press %sF%s to Configure"
+"menu.cpu" = "CPU"
+"menu.memory" = "MEMORY"
+
+# --- Settings screen ---
+"settings.title" = "CONFIGURE CLEANING OPTIONS"
+"settings.keys" = "%sW%s = Up | %sS%s = Down | %sA%s = OFF | %sD%s = ON | %sL%s = Language | %sE%s = Save"
+"settings.save_hint" = "Press %sE%s to Save & Return"
+"settings.saved" = "Configuration saved."
+
+# --- Language picker (reached with L from the settings screen) ---
+"language.title" = "SELECT LANGUAGE"
+"language.keys" = "%s1-9%s = Choose language  |  %sE%s = Save"
+"language.save_hint" = "Press %sE%s to Save & Return"
+
+# --- Shared words ---
+"common.on" = "ON"
+"common.off" = "OFF"
+"common.done" = "Done!"
+"common.skipped" = "SKIPPED"
+"common.press_enter" = "Press ENTER to exit..."
+"common.config_made" = "Config created: %s"
+"common.config_warn" = "Warning loading config: %v"
+"common.fatal" = "Unexpected error: %v"
+
+# --- Cleaner run output ---
+"cleaner.crashed" = "Cleaning pipeline crashed: %v"
+"cleaner.partial" = "Partial results will be shown."
+"cleaner.dns_ok" = "DNS cache flushed"
+"cleaner.dns_fail" = "[SKIP] Could not flush DNS"
+"cleaner.bin_freed" = "Recycle Bin emptied - %s freed"
+"cleaner.bin_empty" = "Recycle Bin emptied - already empty"
+"cleaner.bin_fail" = "[SKIP] Could not empty Recycle Bin"
+"cleaner.reg_fail" = "Could not setup registry for cleanmgr: %v"
+"cleaner.cleanmgr_run" = "Running: cleanmgr.exe /sagerun:99"
+"cleaner.cleanmgr_fail" = "cleanmgr.exe launch failed: %v"
+"cleaner.cleanmgr_wait" = "Waiting for cleanmgr background worker to finish..."
+"cleaner.cleanmgr_ok" = "cleanmgr.exe completed"
+"cleaner.cleanmgr_time" = "cleanmgr.exe timed out (may still be running)"
+
+# --- RAM optimizer ---
+"ram.nothing" = "All RAM Optimization sub-options are OFF - nothing to do"
+"ram.priv_step" = "[Step 1/%d] Enabling SeProfileSingleProcessPrivilege..."
+"ram.priv_ok" = "Privilege enabled successfully"
+"ram.priv_fail" = "FAILED to enable privilege"
+"ram.step" = "[Step %d/%d] %s"
+"ram.trimmed" = "%d processes trimmed, %d skipped (protected/no access)"
+"ram.trim_none" = "No processes trimmed (%d skipped) - run as Administrator"
+"ram.flushed" = "Modified page list flushed - NTSTATUS: %s"
+"ram.flush_fail" = "FlushModifiedList returned NTSTATUS: %s"
+"ram.cache_ok" = "System file cache flushed"
+"ram.cache_fail" = "Could not flush system file cache - run as Administrator"
+"ram.standby_ok" = "Standby list purged - NTSTATUS: %s"
+"ram.standby_fail" = "PurgeStandbyList returned NTSTATUS: %s"
+"ram.results_title" = "SYSTEM RESULTS"
+
+# Per-operation banner and the explanatory note printed under it.
+"ram.trim.title" = "Trimming process working sets..."
+"ram.trim.note" = "(Paging out live app memory - skips the foreground app)"
+"ram.flush.title" = "Flushing modified page list..."
+"ram.flush.note" = "(Writing dirty pages to disk so they can be freed)"
+"ram.cache.title" = "Flushing system file cache..."
+"ram.cache.note" = "(Dropping the kernel's cached file data - safe, cache only)"
+"ram.standby.title" = "Purging standby list..."
+"ram.standby.note" = "(Freeing cached/standby memory - this is the main operation)"
+
+# The four labels below align with each other: 13 characters before the colon.
+"ram.freed" = "RAM Freed    : %d MB"
+"ram.drop" = "Usage Drop   : %.1f%% (%.1f%% -> %.1f%%)"
+"ram.status_ok" = "Status       : SUCCESS - RAM was actually freed"
+"ram.freed_zero" = "RAM Freed    : 0 MB (standby list was already empty)"
+"ram.status_zero" = "Status       : Nothing to free - this is normal if run recently"
+"ram.change" = "RAM Change   : %d MB (background app allocated during cleanup)"
+"ram.status_neg" = "Status       : Try closing background apps and run again"
+
+# Short operation names listed on the summary's "ran:" line.
+"ram.op.trim" = "trim"
+"ram.op.flush" = "flush"
+"ram.op.cache" = "file cache"
+"ram.op.standby" = "standby"
+
+# --- Summary ---
+"summary.title" = "CLEANING SUMMARY"
+"summary.total" = "Total items cleaned : %d"
+"summary.skipped" = "Items skipped       : %d (in use/protected)"
+"summary.items" = "%d items"
+"summary.flushed" = "flushed"
+"summary.subs_off" = "all sub-options OFF"
+"summary.no_priv" = "failed (no privilege)"
+"summary.ram_freed" = "%d MB freed (%.1f%% -> %.1f%%, -%.1f%%)"
+"summary.ram_zero" = "0 MB (already optimal)"
+"summary.ram_neg" = "%d MB (background app allocated)"
+"summary.ran" = "ran: %s"
+"summary.procs" = "%s [%d procs trimmed, %d skipped]"
+"summary.failed" = "failed"
+"summary.bin_freed" = "%s freed"
+"summary.bin_empty" = "already empty"
+"summary.partial" = "partial/failed"
+"summary.completed" = "completed"
+"summary.all_done" = "ALL DONE - Performance Boost Complete!"
+
+# --- Elevation ---
+"priv.requesting" = "Requesting administrator privileges..."
+"priv.exe_error" = "Error obtaining executable path: %v"
+"priv.failed" = "Failed to elevate process (error code %d)."
+
+# --- --version / --help ---
+"version.license" = "GPL-3.0-or-later - free software, with no warranty"
+"version.compare" = "Compare with the checksum on %s/releases"
+"help.tagline" = "%s v%s - Windows system cleaner and RAM optimizer"
+"help.usage" = "Usage: %s [flag]"
+"help.no_flag" = "(no flag)          Launch the interactive menu"
+"help.version" = "-v, --version      Version, author, license and checksum"
+"help.help" = "-h, --help         Show this help"

--- a/locales/active.es.toml
+++ b/locales/active.es.toml
@@ -1,0 +1,190 @@
+# Quiesce - Spanish (neutral / Latin American)
+#
+# Windows API and tool names are kept in English on purpose - Windows itself
+# does not translate Prefetch, DNS, Temp, cleanmgr or NTSTATUS, so translating
+# them would make this output harder to match against what Windows shows.
+#
+# Accents are written properly. EnableUTF8Console in ui.go switches the console
+# to UTF-8 so they render correctly - never strip accents to work around a
+# console encoding problem.
+#
+# This file is also the template for new languages: copy it to
+# active.<code>.toml and translate every value, leaving keys and %-verbs alone.
+
+# --- Pasos de limpieza: etiqueta / encabezado de progreso / resumen ---
+"step.1.name" = "Carpeta Temp de Windows"
+"step.1.action" = "Limpiando la carpeta Temp de Windows..."
+"step.1.short" = "Temp de Windows"
+
+"step.2.name" = "Carpeta Temp del usuario"
+"step.2.action" = "Limpiando la carpeta Temp del usuario..."
+"step.2.short" = "Temp del usuario"
+
+"step.3.name" = "Carpeta Prefetch"
+"step.3.action" = "Limpiando la carpeta Prefetch..."
+"step.3.short" = "Prefetch"
+
+"step.4.name" = "Informes de errores de Windows"
+"step.4.action" = "Limpiando los informes de errores de Windows..."
+"step.4.short" = "Informes de errores"
+
+"step.5.name" = "Optimización de entrega"
+"step.5.action" = "Limpiando la caché de Optimización de entrega..."
+"step.5.short" = "Optimización de entrega"
+
+"step.6.name" = "Caché de Windows Update"
+"step.6.action" = "Limpiando la caché de Windows Update..."
+"step.6.short" = "Caché de Windows Update"
+
+"step.7.name" = "Archivos de registro de Windows"
+"step.7.action" = "Limpiando los archivos de registro de Windows..."
+"step.7.short" = "Registros de Windows"
+
+"step.8.name" = "Temp de Windows Installer"
+"step.8.action" = "Limpiando Temp de Windows Installer..."
+"step.8.short" = "Temp del instalador"
+
+"step.9.name" = "Vaciar caché DNS"
+"step.9.action" = "Vaciando la caché DNS..."
+"step.9.short" = "Caché DNS"
+
+"step.10.name" = "Optimización de RAM"
+"step.10.action" = "Optimizando la RAM..."
+"step.10.short" = "Optimización de RAM"
+
+"step.11.name" = "Vaciar Papelera de reciclaje"
+"step.11.action" = "Vaciando la Papelera de reciclaje..."
+"step.11.short" = "Papelera de reciclaje"
+
+"step.12.name" = "Limpieza profunda"
+"step.12.action" = "Limpieza profunda - AGRESIVA..."
+"step.12.short" = "Limpieza profunda"
+"step.12.tag" = "UNA VEZ"
+
+# --- Sub-opciones de Optimización de RAM ---
+"sub.101.name" = "Vaciar lista modificada"
+"sub.101.note" = "páginas sucias al disco"
+"sub.102.name" = "Purgar lista de reserva"
+"sub.102.note" = "libera memoria en caché"
+"sub.103.name" = "Caché de archivos"
+"sub.103.note" = "caché de disco del kernel"
+"sub.104.name" = "Recortar conjuntos"
+"sub.104.note" = "memoria de apps, agresivo"
+
+# --- Menú principal ---
+"menu.will_clean" = "Esto va a limpiar:"
+"menu.hint" = "Pulsa %sENTER%s para Ejecutar  |  Pulsa %sF%s para Configurar"
+"menu.cpu" = "CPU"
+"menu.memory" = "MEMORIA"
+
+# --- Pantalla de configuración ---
+"settings.title" = "CONFIGURAR OPCIONES DE LIMPIEZA"
+"settings.keys" = "%sW%s = Arriba | %sS%s = Abajo | %sA%s = OFF | %sD%s = ON | %sL%s = Idioma | %sE%s = Guardar"
+"settings.save_hint" = "Pulsa %sE%s para Guardar y Volver"
+"settings.saved" = "Configuración guardada."
+
+# --- Selector de idioma (se abre con L desde la pantalla de configuración) ---
+"language.title" = "SELECCIONAR IDIOMA"
+"language.keys" = "%s1-9%s = Elegir idioma  |  %sE%s = Guardar"
+"language.save_hint" = "Pulsa %sE%s para Guardar y Volver"
+
+# --- Palabras comunes ---
+"common.on" = "ON"
+"common.off" = "OFF"
+"common.done" = "¡Listo!"
+"common.skipped" = "OMITIDO"
+"common.press_enter" = "Pulsa ENTER para salir..."
+"common.config_made" = "Configuración creada: %s"
+"common.config_warn" = "Advertencia al cargar la configuración: %v"
+"common.fatal" = "Error inesperado: %v"
+
+# --- Salida del limpiador ---
+"cleaner.crashed" = "El proceso de limpieza falló: %v"
+"cleaner.partial" = "Se mostrarán los resultados parciales."
+"cleaner.dns_ok" = "Caché DNS vaciada"
+"cleaner.dns_fail" = "[SKIP] No se pudo vaciar la caché DNS"
+"cleaner.bin_freed" = "Papelera de reciclaje vaciada - %s liberados"
+"cleaner.bin_empty" = "Papelera de reciclaje vaciada - ya estaba vacía"
+"cleaner.bin_fail" = "[SKIP] No se pudo vaciar la Papelera de reciclaje"
+"cleaner.reg_fail" = "No se pudo preparar el registro para cleanmgr: %v"
+"cleaner.cleanmgr_run" = "Ejecutando: cleanmgr.exe /sagerun:99"
+"cleaner.cleanmgr_fail" = "No se pudo iniciar cleanmgr.exe: %v"
+"cleaner.cleanmgr_wait" = "Esperando a que termine el proceso en segundo plano de cleanmgr..."
+"cleaner.cleanmgr_ok" = "cleanmgr.exe completado"
+"cleaner.cleanmgr_time" = "cleanmgr.exe agotó el tiempo de espera (puede seguir en ejecución)"
+
+# --- Optimizador de RAM ---
+"ram.nothing" = "Todas las sub-opciones de Optimización de RAM están en OFF - nada que hacer"
+"ram.priv_step" = "[Paso 1/%d] Habilitando SeProfileSingleProcessPrivilege..."
+"ram.priv_ok" = "Privilegio habilitado correctamente"
+"ram.priv_fail" = "FALLÓ al habilitar el privilegio"
+"ram.step" = "[Paso %d/%d] %s"
+"ram.trimmed" = "%d procesos recortados, %d omitidos (protegidos/sin acceso)"
+"ram.trim_none" = "Ningún proceso recortado (%d omitidos) - ejecuta como Administrador"
+"ram.flushed" = "Lista de páginas modificadas vaciada - NTSTATUS: %s"
+"ram.flush_fail" = "FlushModifiedList devolvió NTSTATUS: %s"
+"ram.cache_ok" = "Caché de archivos del sistema vaciada"
+"ram.cache_fail" = "No se pudo vaciar la caché de archivos del sistema - ejecuta como Administrador"
+"ram.standby_ok" = "Lista de reserva purgada - NTSTATUS: %s"
+"ram.standby_fail" = "PurgeStandbyList devolvió NTSTATUS: %s"
+"ram.results_title" = "RESULTADOS DEL SISTEMA"
+
+# Encabezado de cada operación y la nota explicativa que va debajo.
+"ram.trim.title" = "Recortando los conjuntos de trabajo de los procesos..."
+"ram.trim.note" = "(Saca de memoria las apps activas - omite la app en primer plano)"
+"ram.flush.title" = "Vaciando la lista de páginas modificadas..."
+"ram.flush.note" = "(Escribe las páginas sucias en disco para poder liberarlas)"
+"ram.cache.title" = "Vaciando la caché de archivos del sistema..."
+"ram.cache.note" = "(Descarta los datos de archivos en caché del kernel - seguro, solo caché)"
+"ram.standby.title" = "Purgando la lista de reserva..."
+"ram.standby.note" = "(Libera la memoria en caché/reserva - esta es la operación principal)"
+
+# Las cuatro etiquetas siguientes se alinean entre sí: 13 caracteres antes de
+# los dos puntos, igual que en inglés.
+"ram.freed" = "RAM liberada : %d MB"
+"ram.drop" = "Caída de uso : %.1f%% (%.1f%% -> %.1f%%)"
+"ram.status_ok" = "Estado       : ÉXITO - se liberó RAM realmente"
+"ram.freed_zero" = "RAM liberada : 0 MB (la lista de reserva ya estaba vacía)"
+"ram.status_zero" = "Estado       : Nada que liberar - es normal si se ejecutó hace poco"
+"ram.change" = "Cambio de RAM: %d MB (una app en segundo plano reservó memoria)"
+"ram.status_neg" = "Estado       : Cierra apps en segundo plano e inténtalo de nuevo"
+
+# Nombres cortos que aparecen en la línea "ejecutado:" del resumen.
+"ram.op.trim" = "recorte"
+"ram.op.flush" = "vaciado"
+"ram.op.cache" = "caché de archivos"
+"ram.op.standby" = "reserva"
+
+# --- Resumen ---
+"summary.title" = "RESUMEN DE LIMPIEZA"
+"summary.total" = "Elementos limpiados : %d"
+"summary.skipped" = "Elementos omitidos  : %d (en uso/protegidos)"
+"summary.items" = "%d elementos"
+"summary.flushed" = "vaciada"
+"summary.subs_off" = "todas las sub-opciones en OFF"
+"summary.no_priv" = "falló (sin privilegios)"
+"summary.ram_freed" = "%d MB liberados (%.1f%% -> %.1f%%, -%.1f%%)"
+"summary.ram_zero" = "0 MB (ya estaba óptimo)"
+"summary.ram_neg" = "%d MB (reservados por una app en segundo plano)"
+"summary.ran" = "ejecutado: %s"
+"summary.procs" = "%s [%d procesos recortados, %d omitidos]"
+"summary.failed" = "falló"
+"summary.bin_freed" = "%s liberados"
+"summary.bin_empty" = "ya estaba vacía"
+"summary.partial" = "parcial/fallido"
+"summary.completed" = "completado"
+"summary.all_done" = "¡TODO LISTO - Mejora de rendimiento completada!"
+
+# --- Elevación de privilegios ---
+"priv.requesting" = "Solicitando privilegios de administrador..."
+"priv.exe_error" = "Error al obtener la ruta del ejecutable: %v"
+"priv.failed" = "No se pudo elevar el proceso (código de error %d)."
+
+# --- --version / --help ---
+"version.license" = "GPL-3.0-or-later - software libre, sin ninguna garantía"
+"version.compare" = "Compara con la suma de verificación en %s/releases"
+"help.tagline" = "%s v%s - Limpiador del sistema y optimizador de RAM para Windows"
+"help.usage" = "Uso: %s [opción]"
+"help.no_flag" = "(sin opción)       Abre el menú interactivo"
+"help.version" = "-v, --version      Versión, autor, licencia y suma de verificación"
+"help.help" = "-h, --help         Muestra esta ayuda"

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 			fmt.Printf("\n\x1b[31m[FATAL]\x1b[0m %s\n", Tf("common.fatal", r))
 			fmt.Print(T("common.press_enter"))
 			bufio.NewReader(os.Stdin).ReadString('\n')
+			RestoreConsoleMode()
 			os.Exit(1)
 		}
 	}()
@@ -42,6 +43,12 @@ func main() {
 	// across the elevation anyway.
 	EnableVirtualTerminalProcessing()
 	EnableUTF8Console()
+	DisableQuickEditMode()
+
+	// Covers the paths that return normally rather than calling os.Exit -
+	// notably --version and --help, which exit before the menu ever opens.
+	// Calls made on the os.Exit paths are separate and harmless to repeat.
+	defer RestoreConsoleMode()
 
 	// The config path is resolved, and the UI language settled, before ANY
 	// output. InitLanguage needs the config file for its LANGUAGE= override,
@@ -57,13 +64,17 @@ func main() {
 	// Ensure Administrator privilege
 	EnsureAdmin()
 
-	// Re-apply console setup: EnsureAdmin relaunches into a fresh console,
-	// so ANSI colors and the UTF-8 code page have to be enabled again.
+	// Re-apply console setup: EnsureAdmin relaunches into a fresh console, so
+	// ANSI colors, the UTF-8 code page and the QuickEdit fix all have to be
+	// applied again to the new console.
 	EnableVirtualTerminalProcessing()
 	EnableUTF8Console()
+	DisableQuickEditMode()
 
-	// Set a clean console window title instead of showing the exe's file path
-	SetConsoleTitle("Quiesce")
+	// Set a clean console window title instead of showing the exe's file
+	// path. The version is included so a screenshot always says which build
+	// it came from.
+	SetConsoleTitle(AppName + " v" + Version)
 
 	// Load configuration
 	cfg, err := LoadConfig(configFilePath)
@@ -124,6 +135,7 @@ func main() {
 		// before the summary has been read.
 		fmt.Print(T("common.press_enter"))
 		WaitForEnter()
+		RestoreConsoleMode()
 		os.Exit(0)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -29,8 +28,8 @@ func main() {
 	// so the user can read the error instead of the window vanishing.
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Printf("\n\x1b[31m[FATAL]\x1b[0m Unexpected error: %v\n", r)
-			fmt.Print("Press ENTER to exit...")
+			fmt.Printf("\n\x1b[31m[FATAL]\x1b[0m %s\n", Tf("common.fatal", r))
+			fmt.Print(T("common.press_enter"))
 			bufio.NewReader(os.Stdin).ReadString('\n')
 			os.Exit(1)
 		}
@@ -42,6 +41,15 @@ func main() {
 	// EnsureAdmin relaunches without arguments, so a flag would be lost
 	// across the elevation anyway.
 	EnableVirtualTerminalProcessing()
+	EnableUTF8Console()
+
+	// The config path is resolved, and the UI language settled, before ANY
+	// output. InitLanguage needs the config file for its LANGUAGE= override,
+	// and --version/--help and the elevation prompt all print before
+	// LoadConfig would otherwise run.
+	configFilePath := ConfigFilePath()
+	InitLanguage(configFilePath)
+
 	if HandleCLIFlags(os.Args[1:]) {
 		return
 	}
@@ -49,31 +57,22 @@ func main() {
 	// Ensure Administrator privilege
 	EnsureAdmin()
 
-	// Enable ANSI terminal color support in Windows console
+	// Re-apply console setup: EnsureAdmin relaunches into a fresh console,
+	// so ANSI colors and the UTF-8 code page have to be enabled again.
 	EnableVirtualTerminalProcessing()
+	EnableUTF8Console()
 
 	// Set a clean console window title instead of showing the exe's file path
 	SetConsoleTitle("Quiesce")
 
-	// Determine configuration file path alongside executable
-	exePath, err := os.Executable()
-	var exeDir string
-	if err == nil {
-		exeDir = filepath.Dir(exePath)
-	} else {
-		exeDir = "."
-	}
-	configFilePath := filepath.Join(exeDir, "cleaner_config.dat")
-
 	// Load configuration
 	cfg, err := LoadConfig(configFilePath)
 	if err != nil {
-		fmt.Printf("Warning loading config: %v\n", err)
+		fmt.Printf("%s\n", Tf("common.config_warn", err))
 	}
 
 	osP1, osP2 := GetOSVersionParts()
 	host, user := GetHostAndUser()
-
 
 	for {
 		ClearScreen()
@@ -123,7 +122,7 @@ func main() {
 		// WaitForEnter flushes anything typed during the run first, so ENTER
 		// presses made while cleaning was in progress can't close the window
 		// before the summary has been read.
-		fmt.Print("Press ENTER to exit...")
+		fmt.Print(T("common.press_enter"))
 		WaitForEnter()
 		os.Exit(0)
 	}

--- a/privilege.go
+++ b/privilege.go
@@ -57,10 +57,10 @@ func EnsureAdmin() {
 		return
 	}
 
-	fmt.Println("Requesting administrator privileges...")
+	fmt.Println(T("priv.requesting"))
 	exePath, err := os.Executable()
 	if err != nil {
-		fmt.Printf("Error obtaining executable path: %v\n", err)
+		fmt.Printf("%s\n", Tf("priv.exe_error", err))
 		os.Exit(1)
 	}
 
@@ -82,7 +82,7 @@ func EnsureAdmin() {
 	)
 
 	if ret <= 32 {
-		fmt.Printf("Failed to elevate process (error code %d).\n", ret)
+		fmt.Printf("%s\n", Tf("priv.failed", ret))
 	}
 	os.Exit(0)
 }

--- a/privilege.go
+++ b/privilege.go
@@ -61,6 +61,7 @@ func EnsureAdmin() {
 	exePath, err := os.Executable()
 	if err != nil {
 		fmt.Printf("%s\n", Tf("priv.exe_error", err))
+		RestoreConsoleMode()
 		os.Exit(1)
 	}
 
@@ -84,5 +85,6 @@ func EnsureAdmin() {
 	if ret <= 32 {
 		fmt.Printf("%s\n", Tf("priv.failed", ret))
 	}
+	RestoreConsoleMode()
 	os.Exit(0)
 }

--- a/ramclean.go
+++ b/ramclean.go
@@ -374,67 +374,67 @@ func RunRamCleaner(cfg *Config) RamResult {
 	var steps []ramStep
 
 	if cfg.RamTrimWorkingSets == 1 {
-		result.OpsRun = append(result.OpsRun, "trim")
+		result.OpsRun = append(result.OpsRun, T("ram.op.trim"))
 		steps = append(steps, ramStep{
-			"Trimming process working sets...",
-			"(Paging out live app memory - skips the foreground app)",
+			T("ram.trim.title"),
+			T("ram.trim.note"),
 			func() {
 				trimmed, skipped := TrimAllWorkingSets()
 				result.Trimmed = trimmed
 				result.TrimSkipped = skipped
 				if trimmed > 0 {
-					fmt.Printf("    \x1b[31m%d processes trimmed, %d skipped (protected/no access)\x1b[0m\n", trimmed, skipped)
+					fmt.Printf("    \x1b[31m%s\x1b[0m\n", Tf("ram.trimmed", trimmed, skipped))
 				} else {
-					fmt.Printf("    \x1b[33mNo processes trimmed (%d skipped) - run as Administrator\x1b[0m\n", skipped)
+					fmt.Printf("    \x1b[33m%s\x1b[0m\n", Tf("ram.trim_none", skipped))
 				}
 			},
 		})
 	}
 
 	if cfg.RamFlushModified == 1 {
-		result.OpsRun = append(result.OpsRun, "flush")
+		result.OpsRun = append(result.OpsRun, T("ram.op.flush"))
 		steps = append(steps, ramStep{
-			"Flushing modified page list...",
-			"(Writing dirty pages to disk so they can be freed)",
+			T("ram.flush.title"),
+			T("ram.flush.note"),
 			func() {
 				res := FlushModifiedList()
 				status := FormatNTSTATUS(res)
 				if res == 0 {
-					fmt.Printf("    \x1b[31mModified page list flushed - NTSTATUS: %s\x1b[0m\n", status)
+					fmt.Printf("    \x1b[31m%s\x1b[0m\n", Tf("ram.flushed", status))
 				} else {
-					fmt.Printf("    \x1b[33mFlushModifiedList returned NTSTATUS: %s\x1b[0m\n", status)
+					fmt.Printf("    \x1b[33m%s\x1b[0m\n", Tf("ram.flush_fail", status))
 				}
 			},
 		})
 	}
 
 	if cfg.RamFileCache == 1 {
-		result.OpsRun = append(result.OpsRun, "file cache")
+		result.OpsRun = append(result.OpsRun, T("ram.op.cache"))
 		steps = append(steps, ramStep{
-			"Flushing system file cache...",
-			"(Dropping the kernel's cached file data - safe, cache only)",
+			T("ram.cache.title"),
+			T("ram.cache.note"),
 			func() {
 				if PurgeSystemFileCache() {
-					fmt.Println("    \x1b[31mSystem file cache flushed\x1b[0m")
+					fmt.Printf("    \x1b[31m%s\x1b[0m\n", T("ram.cache_ok"))
 				} else {
-					fmt.Println("    \x1b[33mCould not flush system file cache - run as Administrator\x1b[0m")
+					fmt.Printf("    \x1b[33m%s\x1b[0m\n", T("ram.cache_fail"))
 				}
 			},
 		})
 	}
 
 	if cfg.RamPurgeStandby == 1 {
-		result.OpsRun = append(result.OpsRun, "standby")
+		result.OpsRun = append(result.OpsRun, T("ram.op.standby"))
 		steps = append(steps, ramStep{
-			"Purging standby list...",
-			"(Freeing cached/standby memory - this is the main operation)",
+			T("ram.standby.title"),
+			T("ram.standby.note"),
 			func() {
 				res := PurgeStandbyList()
 				status := FormatNTSTATUS(res)
 				if res == 0 {
-					fmt.Printf("    \x1b[31mStandby list purged - NTSTATUS: %s\x1b[0m\n", status)
+					fmt.Printf("    \x1b[31m%s\x1b[0m\n", Tf("ram.standby_ok", status))
 				} else {
-					fmt.Printf("    \x1b[33mPurgeStandbyList returned NTSTATUS: %s\x1b[0m\n", status)
+					fmt.Printf("    \x1b[33m%s\x1b[0m\n", Tf("ram.standby_fail", status))
 				}
 			},
 		})
@@ -442,7 +442,7 @@ func RunRamCleaner(cfg *Config) RamResult {
 
 	if len(steps) == 0 {
 		fmt.Println()
-		fmt.Println("    \x1b[33mAll RAM Optimization sub-options are OFF - nothing to do\x1b[0m")
+		fmt.Printf("    \x1b[33m%s\x1b[0m\n", T("ram.nothing"))
 		result.NothingToRun = true
 		return result
 	}
@@ -451,18 +451,18 @@ func RunRamCleaner(cfg *Config) RamResult {
 
 	// --- Step 1: Enable privilege ---
 	fmt.Println()
-	fmt.Printf("  \x1b[36m[Step 1/%d] Enabling SeProfileSingleProcessPrivilege...\x1b[0m\n", total)
+	fmt.Printf("  \x1b[36m%s\x1b[0m\n", Tf("ram.priv_step", total))
 	if EnablePrivilege() {
-		fmt.Println("    \x1b[31mPrivilege enabled successfully\x1b[0m")
+		fmt.Printf("    \x1b[31m%s\x1b[0m\n", T("ram.priv_ok"))
 	} else {
-		fmt.Println("    \x1b[33mFAILED to enable privilege\x1b[0m")
+		fmt.Printf("    \x1b[33m%s\x1b[0m\n", T("ram.priv_fail"))
 		result.PrivFailed = true
 		return result
 	}
 
 	for i, s := range steps {
 		fmt.Println()
-		fmt.Printf("  \x1b[36m[Step %d/%d] %s\x1b[0m\n", i+2, total, s.title)
+		fmt.Printf("  \x1b[36m%s\x1b[0m\n", Tf("ram.step", i+2, total, s.title))
 		fmt.Printf("    %s\n", s.note)
 		s.run()
 	}
@@ -486,19 +486,19 @@ func RunRamCleaner(cfg *Config) RamResult {
 
 	fmt.Println()
 	fmt.Println("  +---------------------------------------+")
-	fmt.Println("             \x1b[36mSYSTEM RESULTS\x1b[0m")
+	fmt.Printf("  \x1b[36m%s\x1b[0m\n", centerInBox(T("ram.results_title")))
 	fmt.Println("  +---------------------------------------+")
 
 	if freedMB > 0 {
-		fmt.Printf("    \x1b[31mRAM Freed    : %d MB\x1b[0m\n", freedMB)
-		fmt.Printf("    \x1b[31mUsage Drop   : %.1f%% (%.1f%% -> %.1f%%)\x1b[0m\n", dropPct, before.UsedPercent, after.UsedPercent)
-		fmt.Println("    \x1b[31mStatus       : SUCCESS - RAM was actually freed\x1b[0m")
+		fmt.Printf("    \x1b[31m%s\x1b[0m\n", Tf("ram.freed", freedMB))
+		fmt.Printf("    \x1b[31m%s\x1b[0m\n", Tf("ram.drop", dropPct, before.UsedPercent, after.UsedPercent))
+		fmt.Printf("    \x1b[31m%s\x1b[0m\n", T("ram.status_ok"))
 	} else if freedMB == 0 {
-		fmt.Println("    \x1b[33mRAM Freed    : 0 MB (standby list was already empty)\x1b[0m")
-		fmt.Println("    \x1b[33mStatus       : Nothing to free - this is normal if run recently\x1b[0m")
+		fmt.Printf("    \x1b[33m%s\x1b[0m\n", T("ram.freed_zero"))
+		fmt.Printf("    \x1b[33m%s\x1b[0m\n", T("ram.status_zero"))
 	} else {
-		fmt.Printf("    \x1b[33mRAM Change   : %d MB (background app allocated during cleanup)\x1b[0m\n", freedMB)
-		fmt.Println("    \x1b[33mStatus       : Try closing background apps and run again\x1b[0m")
+		fmt.Printf("    \x1b[33m%s\x1b[0m\n", Tf("ram.change", freedMB))
+		fmt.Printf("    \x1b[33m%s\x1b[0m\n", T("ram.status_neg"))
 	}
 
 	// No CPU/Memory box here on purpose: the same numbers are already in the

--- a/ui.go
+++ b/ui.go
@@ -34,7 +34,11 @@ var (
 	procSetConsoleTitle = modkernel32Title.NewProc("SetConsoleTitleW")
 
 	procFlushConsoleInputBuffer = modkernel32Title.NewProc("FlushConsoleInputBuffer")
+	procSetConsoleOutputCP      = modkernel32Title.NewProc("SetConsoleOutputCP")
 )
+
+// CP_UTF8 is the Windows code page identifier for UTF-8.
+const CP_UTF8 = 65001
 
 const (
 	RED    = "\x1b[31m"
@@ -108,7 +112,7 @@ func StartLiveStatsRow(promptRow int) *liveStats {
 		paint := func() {
 			stats := GetSystemStats()
 			line := fmt.Sprintf(
-				"  CPU : %s%d%%%s  -  MEMORY: %s%.2f/%.2f GB%s %s%d%%%s",
+				"  "+T("menu.cpu")+" : %s%d%%%s  -  "+T("menu.memory")+": %s%.2f/%.2f GB%s %s%d%%%s",
 				RED, stats.CpuLoad, RST,
 				RED, stats.UsedGB, stats.TotalGB, RST,
 				RED, stats.Pct, RST,
@@ -159,6 +163,24 @@ func StopLiveStatsRow(ls *liveStats) {
 	}
 	close(ls.stop)
 	<-ls.done
+}
+
+// EnableUTF8Console switches the console's output code page to UTF-8.
+//
+// Go source and therefore every translated string is UTF-8, but a Windows
+// console defaults to a legacy OEM code page (437/850/852...) that has no
+// idea what to do with multi-byte sequences. Without this, Spanish accents
+// and inverted punctuation render as mojibake ("OptimizaciÃ³n"), which is why
+// translations must NOT work around the problem by stripping accents.
+//
+// Failure is ignored: on the rare console where this is refused, output
+// degrades to garbled accents rather than the app refusing to start. The box
+// drawing and menu keys are plain ASCII either way.
+func EnableUTF8Console() {
+	if procSetConsoleOutputCP.Find() != nil {
+		return
+	}
+	procSetConsoleOutputCP.Call(uintptr(CP_UTF8))
 }
 
 func EnableVirtualTerminalProcessing() {
@@ -256,48 +278,136 @@ func WaitForEnter() {
 	}
 }
 
-func GetCfgDispName(index int) string {
-	switch index {
-	case 1:
-		return "[1]  Windows Temp folder     "
-	case 2:
-		return "[2]  User Temp folder        "
-	case 3:
-		return "[3]  Prefetch folder         "
-	case 4:
-		return "[4]  Windows Error Reports   "
-	case 5:
-		return "[5]  Delivery Optimization   "
-	case 6:
-		return "[6]  Windows Update Cache    "
-	case 7:
-		return "[7]  Windows Log Files       "
-	case 8:
-		return "[8]  Windows Installer Temp  "
-	case 9:
-		return "[9]  DNS Cache Flush         "
-	case 10:
-		return "[10] RAM Optimization        "
-	case 11:
-		return "[11] Empty Recycle Bin       "
-	// 101-104: RAM Optimization sub-options, shown indented under [10].
-	// All four strings are the same length so their ON/OFF column lines up.
-	case 101:
-		return "  - Flush modified list  (dirty pages to disk)"
-	case 102:
-		return "  - Purge standby list   (frees cached memory)"
-	case 103:
-		return "  - System file cache    (kernel disk cache)  "
-	case 104:
-		return "  - Trim working sets    (app memory, harsh)  "
-	default:
-		return ""
-	}
-}
+// mainStepIndices are the top-level cleaning steps in display order. Step 12
+// (Deep Cleanup) is included for label/width purposes even though its toggle
+// lives outside Config's GetVal/SetVal.
+var mainStepIndices = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
 // ramSubOptions are the config indices of the RAM Optimization sub-toggles,
 // in display order.
 var ramSubOptions = []int{101, 102, 103, 104}
+
+// stepLabel builds the label for a top-level step in two forms: the plain
+// text, used for width and padding math, and the colored text actually
+// printed. They differ only for Deep Cleanup, whose "RUN ONCE" tag is red -
+// ANSI escapes have zero visible width but do count toward len(), so padding
+// must always be measured on the plain form or the column drifts.
+func stepLabel(index int) (plain, colored string) {
+	num := fmt.Sprintf("[%d]", index)
+	name := T(fmt.Sprintf("step.%d.name", index))
+
+	if index == 12 {
+		tag := T("step.12.tag")
+		plain = fmt.Sprintf("%-5s%s - %s", num, name, tag)
+		colored = fmt.Sprintf("%-5s%s - %s%s%s", num, name, RED, tag, RST)
+		return plain, colored
+	}
+
+	plain = fmt.Sprintf("%-5s%s", num, name)
+	return plain, plain
+}
+
+// subLabel builds an indented RAM sub-option label: "  - <name> (<note>)".
+// The name is padded to the widest name in the group so every "(" lines up,
+// whatever the language.
+func subLabel(index int) string {
+	w := maxKeyWidth(
+		"sub.101.name", "sub.102.name", "sub.103.name", "sub.104.name",
+	)
+	name := padRight(T(fmt.Sprintf("sub.%d.name", index)), w)
+	return fmt.Sprintf("  - %s (%s)", name, T(fmt.Sprintf("sub.%d.note", index)))
+}
+
+// mainLabelWidth and subLabelWidth give each group its own ON/OFF column,
+// matching the original layout where the indented sub-options sit further
+// right than the numbered steps. Widths are measured, not typed, so a longer
+// translation shifts the column instead of breaking the alignment.
+func mainLabelWidth() int {
+	w := 0
+	for _, i := range mainStepIndices {
+		plain, _ := stepLabel(i)
+		w = max(w, len([]rune(plain)))
+	}
+	return w
+}
+
+func subLabelWidth() int {
+	w := 0
+	for _, i := range ramSubOptions {
+		w = max(w, len([]rune(subLabel(i))))
+	}
+	return w
+}
+
+// GetCfgDispName returns the display label for a config index, already
+// padded so the ON/OFF column that follows lines up with its group.
+func GetCfgDispName(index int) string {
+	if index >= 101 {
+		return padRight(subLabel(index), subLabelWidth())
+	}
+	if index < 1 || index > 12 {
+		return ""
+	}
+	plain, colored := stepLabel(index)
+	if pad := mainLabelWidth() - len([]rune(plain)); pad > 0 {
+		colored += strings.Repeat(" ", pad)
+	}
+	return colored
+}
+
+// StepHeader prints the "[n/12] <action>..." banner shown while a step runs.
+// Deep Cleanup (12) is printed in red, as it always was, because it is the
+// one destructive step.
+func StepHeader(idx int) {
+	head := fmt.Sprintf("[%d/12] %s", idx, T(fmt.Sprintf("step.%d.action", idx)))
+	if idx == 12 {
+		head = RED + head + RST
+	}
+	TypeLine(head, 0)
+}
+
+// StepSkipped prints the one-line "[n/12] <name> - SKIPPED" notice for a step
+// that is switched off. The label is padded to the widest "[n/12] <name>" in
+// the current language so every dash lines up, which is what the typed
+// trailing spaces in the original English strings were doing by hand.
+func StepSkipped(idx int) {
+	head := func(i int) string {
+		return fmt.Sprintf("[%d/12] %s", i, T(fmt.Sprintf("step.%d.name", i)))
+	}
+	w := 0
+	for i := 1; i <= 12; i++ {
+		w = max(w, len([]rune(head(i))))
+	}
+	fmt.Printf("%s - %s%s%s\n", padRight(head(idx), w), CYAN, T("common.skipped"), RST)
+}
+
+// selectedMark is the tick shown beside the active language. The console is
+// switched to UTF-8 at startup, so this renders on Windows Terminal and
+// modern conhost; it is two columns wide to match the blank alternative.
+const selectedMark = "✓ "
+
+// boxWidth is the visible width of the "+---...---+" rules used as screen
+// headers, including both "+" characters.
+const boxWidth = 41
+
+// centerInBox pads a heading with leading spaces so it sits centered under
+// the box rule. Headings used to carry hand-typed indentation, which only
+// looked centered for the exact English wording.
+func centerInBox(s string) string {
+	n := len([]rune(s))
+	if n >= boxWidth {
+		return s
+	}
+	return strings.Repeat(" ", (boxWidth-n)/2) + s
+}
+
+// RenderToggle formats a step's state as a colored [ON] / [OFF] marker.
+func RenderToggle(on bool) string {
+	if on {
+		return fmt.Sprintf("%s[%s]%s", RED, T("common.on"), RST)
+	}
+	return fmt.Sprintf("%s[%s]%s", CYAN, T("common.off"), RST)
+}
 
 // DrawMainMenu prints the main menu and returns the screen row number
 // where the "  > " input prompt will be printed immediately after this
@@ -330,39 +440,26 @@ func DrawMainMenu(cfg *Config, osP1, osP2, host, user string) int {
 	pf("  %s%s%s%s%s\n", WHITE, osP1, RED, osP2, RST)
 	pln("+---------------------------------------+")
 	pln()
-	pf("%sThis will clean:%s\n", WHITE, RST)
+	pf("%s%s%s\n", WHITE, T("menu.will_clean"), RST)
 
 	for i := 1; i <= 11; i++ {
-		disp := GetCfgDispName(i)
 		val := cfg.GetVal(i)
-		if val == 1 {
-			pf("  %s : %s[ON]%s\n", disp, RED, RST)
-		} else {
-			pf("  %s : %s[OFF]%s\n", disp, CYAN, RST)
-		}
+		pf("  %s : %s\n", GetCfgDispName(i), RenderToggle(val == 1))
 
 		// Show which RAM operations will actually run, indented under [10].
 		if i == 10 && val == 1 {
 			for _, sub := range ramSubOptions {
-				if cfg.GetVal(sub) == 1 {
-					pf("  %s : %s[ON]%s\n", GetCfgDispName(sub), RED, RST)
-				} else {
-					pf("  %s : %s[OFF]%s\n", GetCfgDispName(sub), CYAN, RST)
-				}
+				pf("  %s : %s\n", GetCfgDispName(sub), RenderToggle(cfg.GetVal(sub) == 1))
 			}
 		}
 	}
 
 	// Deep Cleanup — inline, right below Recycle Bin
-	if cfg.DeepCleanup == 1 {
-		pf("  [12] Deep Cleanup - %sRUN ONCE%s  : %s[ON]%s\n", RED, RST, RED, RST)
-	} else {
-		pf("  [12] Deep Cleanup - %sRUN ONCE%s  : %s[OFF]%s\n", RED, RST, CYAN, RST)
-	}
+	pf("  %s : %s\n", GetCfgDispName(12), RenderToggle(cfg.DeepCleanup == 1))
 
 	pln()
 	pln("+---------------------------------------+")
-	pf("  Press %sENTER%s to Run  |  Press %sF%s to Configure\n", WHITE, RST, WHITE, RST)
+	pf("  %s\n", Tf("menu.hint", WHITE, RST, WHITE, RST))
 	pln("+---------------------------------------+")
 	pln()
 
@@ -412,9 +509,9 @@ func RunSettingsScreen(cfg *Config, configFilePath string) {
 		statsRowNum := row + 1
 		pln()
 		pf("%s+---------------------------------------+%s\n", WHITE, RST)
-		pf("%s         CONFIGURE CLEANING OPTIONS%s\n", WHITE, RST)
+		pf("%s%s%s\n", WHITE, centerInBox(T("settings.title")), RST)
 		pf("%s+---------------------------------------+%s\n", WHITE, RST)
-		pf("  %sW%s = Up  |  %sS%s = Down  |  %sA%s = OFF  |  %sD%s = ON  |  %sE%s = Save\n", WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST)
+		pf("  %s\n", Tf("settings.keys", WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST, WHITE, RST))
 		pln()
 
 		if statsRowNum != liveStatsRow {
@@ -429,27 +526,19 @@ func RunSettingsScreen(cfg *Config, configFilePath string) {
 			}
 
 			// Deep Cleanup (12) isn't part of Config's GetVal/SetVal - it is
-			// never persisted, so it's read and drawn separately.
+			// never persisted, so its state is read separately. Its label
+			// still comes from GetCfgDispName so it shares the same measured
+			// column as every other step.
+			on := cfg.GetVal(idx) == 1
 			if idx == 12 {
-				if cfg.DeepCleanup == 1 {
-					fmt.Printf("   [12] Deep Cleanup - %sRUN ONCE%s  : %s[ON]%s%s\n", RED, RST, RED, RST, a)
-				} else {
-					fmt.Printf("   [12] Deep Cleanup - %sRUN ONCE%s  : %s[OFF]%s%s\n", RED, RST, CYAN, RST, a)
-				}
-				continue
+				on = cfg.DeepCleanup == 1
 			}
-
-			disp := GetCfgDispName(idx)
-			if cfg.GetVal(idx) == 1 {
-				fmt.Printf("   %s : %s[ON]%s%s\n", disp, RED, RST, a)
-			} else {
-				fmt.Printf("   %s : %s[OFF]%s%s\n", disp, CYAN, RST, a)
-			}
+			fmt.Printf("   %s : %s%s\n", GetCfgDispName(idx), RenderToggle(on), a)
 		}
 
 		pln()
 		pf("%s+---------------------------------------+%s\n", WHITE, RST)
-		pf("  Press %sE%s to Save & Return\n", WHITE, RST)
+		pf("  %s\n", Tf("settings.save_hint", WHITE, RST))
 		pf("%s+---------------------------------------+%s\n", WHITE, RST)
 
 		// Prompt first, then the painter - the painter parks the cursor at
@@ -488,11 +577,105 @@ func RunSettingsScreen(cfg *Config, configFilePath string) {
 			} else {
 				cfg.SetVal(entries[sel], 1)
 			}
+		case "l":
+			// The picker redraws this screen in the new language on return,
+			// because the loop repaints from scratch every iteration.
+			RunLanguageScreen(cfg, configFilePath)
 		case "e":
 			// Save config — DeepCleanup is intentionally NOT saved
 			_ = SaveConfig(configFilePath, cfg)
 			fmt.Println()
-			fmt.Printf("  %s[SAVED]%s Configuration saved.\n", WHITE, RST)
+			fmt.Printf("  %s[SAVED]%s %s\n", WHITE, RST, T("settings.saved"))
+			time.Sleep(1 * time.Second)
+			ClearScreen()
+			return
+		}
+	}
+}
+
+// RunLanguageScreen shows the language picker reached with L from the
+// settings screen. The user presses the number next to a language to switch
+// to it, and E to save and go back.
+//
+// The switch is applied immediately rather than on save, so the list itself
+// redraws in the chosen language - that is the fastest way for someone who
+// picked the wrong entry to realise it and pick again.
+func RunLanguageScreen(cfg *Config, configFilePath string) {
+	codes := AvailableLanguages()
+
+	for {
+		row := 0
+		pln := func(a ...interface{}) {
+			fmt.Println(a...)
+			row++
+		}
+		pf := func(format string, a ...interface{}) {
+			fmt.Printf(format, a...)
+			row++
+		}
+
+		ClearScreen()
+		pln()
+		// Reserved (empty) stats row, painted live - same position as the
+		// main menu and the settings screen.
+		statsRowNum := row + 1
+		pln()
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
+		pf("%s%s%s\n", WHITE, centerInBox(T("language.title")), RST)
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
+		pf("  %s\n", Tf("language.keys", WHITE, RST, WHITE, RST))
+		pln()
+
+		if statsRowNum != liveStatsRow {
+			pf("\x1b[33m[WARN]\x1b[0m liveStatsRow constant (%d) doesn't match actual row (%d). Update liveStatsRow in ui.go.\n", liveStatsRow, statsRowNum)
+		}
+
+		// Names are padded to the widest so the tick column lines up.
+		nameW := 0
+		for _, c := range codes {
+			nameW = max(nameW, len([]rune(LanguageDisplayName(c))))
+		}
+
+		for i, c := range codes {
+			name := padRight(LanguageDisplayName(c), nameW)
+			mark := "  "
+			if c == ActiveLanguage() {
+				mark = selectedMark
+			}
+			pf("   [%d] %s   %s%s%s\n", i+1, name, RED, mark, RST)
+		}
+
+		pln()
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
+		pf("  %s\n", Tf("language.save_hint", WHITE, RST))
+		pf("%s+---------------------------------------+%s\n", WHITE, RST)
+
+		// Prompt first, then the painter - the painter parks the cursor at
+		// the prompt's column, so the prompt has to already be on screen.
+		fmt.Print("  > ")
+		statsStop := StartLiveStatsRow(row + 1)
+
+		ch := ReadSingleKey()
+
+		StopLiveStatsRow(statsStop)
+
+		// Digits select a language by position. Anything out of range is
+		// ignored rather than treated as an error.
+		if ch >= '1' && ch <= '9' {
+			if idx := int(ch - '1'); idx < len(codes) {
+				SetLanguage(codes[idx])
+				cfg.Language = codes[idx]
+			}
+			continue
+		}
+
+		if strings.ToLower(string(ch)) == "e" {
+			// Saving here as well as on the settings screen means a language
+			// picked and confirmed with E is never lost, whichever way the
+			// user leaves the settings screen afterwards.
+			_ = SaveConfig(configFilePath, cfg)
+			fmt.Println()
+			fmt.Printf("  %s[SAVED]%s %s\n", WHITE, RST, T("settings.saved"))
 			time.Sleep(1 * time.Second)
 			ClearScreen()
 			return
@@ -503,92 +686,120 @@ func RunSettingsScreen(cfg *Config, configFilePath string) {
 func PrintSummary(cfg *Config, results StepResults) {
 	fmt.Println()
 	fmt.Println("+---------------------------------------+")
-	fmt.Println("             CLEANING SUMMARY")
+	fmt.Println(centerInBox(T("summary.title")))
 	fmt.Println("+---------------------------------------+")
 	fmt.Println()
-	fmt.Printf("  %sTotal items cleaned : %d%s\n", RED, results.TotalDeleted, RST)
-	fmt.Printf("  Items skipped       : %d (in use/protected)\n", results.TotalFailed)
+	fmt.Printf("  %s%s%s\n", RED, Tf("summary.total", results.TotalDeleted), RST)
+	fmt.Printf("  %s\n", Tf("summary.skipped", results.TotalFailed))
 	fmt.Println()
+
+	// Summary labels are padded to the widest translated label rather than
+	// carrying typed trailing spaces, so the ":" column holds in any language.
+	// Deep Cleanup's row carries its "RUN ONCE" tag inline, making it the
+	// longest label, so it takes part in the width measurement too - it used
+	// to be printed with hand-typed spacing and sat one column off even in
+	// English.
+	deepPlain := fmt.Sprintf("%s - %s", T("step.12.short"), T("step.12.tag"))
+
+	shortKeys := make([]string, 0, 11)
+	for i := 1; i <= 11; i++ {
+		shortKeys = append(shortKeys, fmt.Sprintf("step.%d.short", i))
+	}
+	nameW := max(maxKeyWidth(shortKeys...), len([]rune(deepPlain)))
+
+	// line prints one summary row: "  [n] <label> : <value>".
+	line := func(idx int, value string) {
+		name := padRight(T(fmt.Sprintf("step.%d.short", idx)), nameW)
+		fmt.Printf("  %-5s%s : %s\n", fmt.Sprintf("[%d]", idx), name, value)
+	}
+	dim := func(s string) string { return CYAN + s + RST }
 
 	steps := []struct {
 		idx  int
-		name string
 		cfg  int
 		isSp bool
 	}{
-		{1, "Windows Temp          ", cfg.WinTemp, false},
-		{2, "User Temp             ", cfg.UserTemp, false},
-		{3, "Prefetch              ", cfg.Prefetch, false},
-		{4, "Error Reports         ", cfg.ErrorReports, false},
-		{5, "Delivery Optimization ", cfg.DeliveryOpt, false},
-		{6, "Windows Update Cache  ", cfg.WinUpdate, false},
-		{7, "Windows Log Files     ", cfg.LogFiles, false},
-		{8, "Installer Temp        ", cfg.InstallerTemp, false},
-		{9, "DNS Cache             ", cfg.DnsFlush, true},
-		{10, "RAM Optimization      ", cfg.RamOptimize, true},
-		{11, "Recycle Bin           ", cfg.RecycleBin, true},
+		{1, cfg.WinTemp, false},
+		{2, cfg.UserTemp, false},
+		{3, cfg.Prefetch, false},
+		{4, cfg.ErrorReports, false},
+		{5, cfg.DeliveryOpt, false},
+		{6, cfg.WinUpdate, false},
+		{7, cfg.LogFiles, false},
+		{8, cfg.InstallerTemp, false},
+		{9, cfg.DnsFlush, true},
+		{10, cfg.RamOptimize, true},
+		{11, cfg.RecycleBin, true},
 	}
 
 	for _, s := range steps {
-		label := fmt.Sprintf("[%d]", s.idx)
-		if s.cfg == 1 {
-			if !s.isSp {
-				fmt.Printf("  %-5s%s : %d items\n", label, s.name, results.StepCounts[s.idx])
-			} else if s.idx == 9 {
-				fmt.Printf("  %-5s%s : flushed\n", label, s.name)
-			} else if s.idx == 10 {
-				r := results.Ram
-				switch {
-				case r.NothingToRun:
-					fmt.Printf("  %-5s%s : %sall sub-options OFF%s\n", label, s.name, CYAN, RST)
-				case r.PrivFailed:
-					fmt.Printf("  %-5s%s : %sfailed (no privilege)%s\n", label, s.name, CYAN, RST)
-				case r.FreedMB > 0:
-					fmt.Printf("  %-5s%s : %d MB freed (%.1f%% -> %.1f%%, -%.1f%%)\n",
-						label, s.name, r.FreedMB, r.BeforePct, r.AfterPct, r.DropPct)
-				case r.FreedMB == 0:
-					fmt.Printf("  %-5s%s : 0 MB (already optimal)\n", label, s.name)
-				default:
-					fmt.Printf("  %-5s%s : %s%d MB (background app allocated)%s\n", label, s.name, CYAN, r.FreedMB, RST)
-				}
+		if s.cfg != 1 {
+			line(s.idx, dim(T("common.skipped")))
+			continue
+		}
 
-				// Attribute the number: which of the four operations ran,
-				// and how many processes the trim actually reached.
-				if !r.NothingToRun && !r.PrivFailed && len(r.OpsRun) > 0 {
-					detail := strings.Join(r.OpsRun, ", ")
-					if r.Trimmed > 0 || r.TrimSkipped > 0 {
-						detail = fmt.Sprintf("%s [%d procs trimmed, %d skipped]", detail, r.Trimmed, r.TrimSkipped)
-					}
-					fmt.Printf("       %sran: %s%s\n", CYAN, detail, RST)
-				}
-			} else if s.idx == 11 {
-				if results.RecycleBinFailed {
-					fmt.Printf("  %-5s%s : %sfailed%s\n", label, s.name, CYAN, RST)
-				} else if results.RecycleBinBytes > 0 {
-					fmt.Printf("  %-5s%s : %s freed\n", label, s.name, FormatBytesHuman(results.RecycleBinBytes))
-				} else {
-					fmt.Printf("  %-5s%s : already empty\n", label, s.name)
-				}
+		switch {
+		case !s.isSp:
+			line(s.idx, Tf("summary.items", results.StepCounts[s.idx]))
+
+		case s.idx == 9:
+			line(s.idx, T("summary.flushed"))
+
+		case s.idx == 10:
+			r := results.Ram
+			switch {
+			case r.NothingToRun:
+				line(s.idx, dim(T("summary.subs_off")))
+			case r.PrivFailed:
+				line(s.idx, dim(T("summary.no_priv")))
+			case r.FreedMB > 0:
+				line(s.idx, Tf("summary.ram_freed", r.FreedMB, r.BeforePct, r.AfterPct, r.DropPct))
+			case r.FreedMB == 0:
+				line(s.idx, T("summary.ram_zero"))
+			default:
+				line(s.idx, dim(Tf("summary.ram_neg", r.FreedMB)))
 			}
-		} else {
-			fmt.Printf("  %-5s%s : %sSKIPPED%s\n", label, s.name, CYAN, RST)
+
+			// Attribute the number: which of the four operations ran, and
+			// how many processes the trim actually reached.
+			if !r.NothingToRun && !r.PrivFailed && len(r.OpsRun) > 0 {
+				detail := strings.Join(r.OpsRun, ", ")
+				if r.Trimmed > 0 || r.TrimSkipped > 0 {
+					detail = Tf("summary.procs", detail, r.Trimmed, r.TrimSkipped)
+				}
+				fmt.Printf("       %s%s%s\n", CYAN, Tf("summary.ran", detail), RST)
+			}
+
+		case s.idx == 11:
+			switch {
+			case results.RecycleBinFailed:
+				line(s.idx, dim(T("summary.failed")))
+			case results.RecycleBinBytes > 0:
+				line(s.idx, Tf("summary.bin_freed", FormatBytesHuman(results.RecycleBinBytes)))
+			default:
+				line(s.idx, T("summary.bin_empty"))
+			}
 		}
 	}
 
-	// Deep Cleanup summary line
+	// Deep Cleanup summary line. Its label carries the red "RUN ONCE" tag, so
+	// it is built here rather than through line() - padding is applied from
+	// the plain form, since the color escapes have no visible width.
+	deepTag := fmt.Sprintf("%s - %s%s%s%s", T("step.12.short"), RED, T("step.12.tag"), RST,
+		strings.Repeat(" ", max(0, nameW-len([]rune(deepPlain)))))
+	deepState := dim(T("common.skipped"))
 	if results.DeepCleanupRan {
 		if results.DeepCleanupFailed {
-			fmt.Printf("  [12] Deep Cleanup - %sRUN ONCE%s : %spartial/failed%s\n", RED, RST, CYAN, RST)
+			deepState = dim(T("summary.partial"))
 		} else {
-			fmt.Printf("  [12] Deep Cleanup - %sRUN ONCE%s : %scompleted%s\n", RED, RST, RED, RST)
+			deepState = RED + T("summary.completed") + RST
 		}
-	} else {
-		fmt.Printf("  [12] Deep Cleanup - %sRUN ONCE%s : %sSKIPPED%s\n", RED, RST, CYAN, RST)
 	}
+	fmt.Printf("  %-5s%s : %s\n", "[12]", deepTag, deepState)
 
 	fmt.Println()
 	fmt.Println("+---------------------------------------+")
-	fmt.Println("  ALL DONE - Performance Boost Complete!")
+	fmt.Printf("  %s\n", T("summary.all_done"))
 	fmt.Println("+---------------------------------------+")
 	fmt.Println()
 	fmt.Printf("  %s\n", VersionLine())

--- a/ui.go
+++ b/ui.go
@@ -40,6 +40,25 @@ var (
 // CP_UTF8 is the Windows code page identifier for UTF-8.
 const CP_UTF8 = 65001
 
+// Console input mode flags. These are not exposed by x/sys/windows, so they
+// are declared from the Win32 headers.
+const (
+	// ENABLE_QUICK_EDIT_MODE lets the user select text by dragging the
+	// mouse. It is ON by default and it is a trap for a menu-driven app.
+	ENABLE_QUICK_EDIT_MODE = 0x0040
+
+	// ENABLE_EXTENDED_FLAGS must be set for a change to the quick-edit bit
+	// to be honoured at all - without it SetConsoleMode silently ignores it.
+	ENABLE_EXTENDED_FLAGS = 0x0080
+)
+
+// origInputMode holds the console input settings as they were before Quiesce
+// changed them, so they can be restored on exit.
+var (
+	origInputMode      uint32
+	origInputModeSaved bool
+)
+
 const (
 	RED    = "\x1b[31m"
 	CYAN   = "\x1b[36m"
@@ -181,6 +200,75 @@ func EnableUTF8Console() {
 		return
 	}
 	procSetConsoleOutputCP.Call(uintptr(CP_UTF8))
+}
+
+// DisableQuickEditMode stops a mouse click inside the console window from
+// freezing the program.
+//
+// Windows consoles ship with QuickEdit ON: clicking anywhere in the window
+// puts the console into selection mode, which BLOCKS every subsequent write
+// until the user presses Enter or Esc. The window title gains a "Select "
+// prefix while this is happening, which is the only clue most people get.
+//
+// For Quiesce this is a real hazard rather than a cosmetic one. Someone
+// clicking the window to focus it - the obvious thing to do before pressing
+// a key - can freeze the app mid-clean, with services stopped and no output
+// explaining why. Turning QuickEdit off costs drag-to-select (right-click ->
+// Mark still works, as does Ctrl+Shift+C in Windows Terminal) and removes an
+// entire class of "it hung" report.
+//
+// Every other mode bit is preserved, and failure is ignored: worst case the
+// old click-to-freeze behaviour remains.
+// The change is undone by RestoreConsoleMode on exit, because Quiesce may be
+// running in a terminal the user already had open - leaving their console
+// permanently unable to select text would be a rude side effect of running a
+// cleaner once.
+func DisableQuickEditMode() {
+	handle, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
+	if err != nil {
+		return
+	}
+	var mode uint32
+	if err := windows.GetConsoleMode(handle, &mode); err != nil {
+		return
+	}
+
+	// Remember the console's original settings once, on the first call, so a
+	// later call (after elevation re-runs the console setup) cannot overwrite
+	// the saved value with our own already-modified mode.
+	if !origInputModeSaved {
+		origInputMode = mode
+		origInputModeSaved = true
+	}
+
+	_ = windows.SetConsoleMode(handle, quickEditDisabledMode(mode))
+}
+
+// quickEditDisabledMode returns mode with QuickEdit turned off, extended
+// flags turned on, and every other bit left alone.
+//
+// Split out from DisableQuickEditMode so the bit arithmetic can be tested
+// without a real console attached - under `go test` the standard handles are
+// redirected, so the syscall path cannot be exercised at all.
+func quickEditDisabledMode(mode uint32) uint32 {
+	return (mode | ENABLE_EXTENDED_FLAGS) &^ ENABLE_QUICK_EDIT_MODE
+}
+
+// RestoreConsoleMode puts the console's input settings back the way they were
+// before DisableQuickEditMode touched them.
+//
+// It is safe to call more than once, and does nothing if the mode was never
+// captured. Errors are ignored: the process is on its way out, and there is
+// nothing useful to say to a user whose console is already closing.
+func RestoreConsoleMode() {
+	if !origInputModeSaved {
+		return
+	}
+	handle, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
+	if err != nil {
+		return
+	}
+	_ = windows.SetConsoleMode(handle, origInputMode)
 }
 
 func EnableVirtualTerminalProcessing() {

--- a/ui_test.go
+++ b/ui_test.go
@@ -1,0 +1,208 @@
+package main
+
+// Screen-rendering tests.
+//
+// These capture what the program actually prints and assert on the layout,
+// because the alignment bugs this package is prone to are invisible to the
+// compiler and only show up as a crooked column on someone else's machine.
+
+import (
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// rowRe matches a numbered screen row, e.g. "  [10] RAM Optimization   : ...".
+var rowRe = regexp.MustCompile(`^\s*\[\d+\]`)
+
+// captureStdout runs fn with os.Stdout redirected, and returns what was
+// printed with ANSI color escapes stripped.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	func() {
+		defer func() {
+			os.Stdout = orig
+			w.Close()
+		}()
+		fn()
+	}()
+
+	return ansiRe.ReplaceAllString(<-done, "")
+}
+
+// colonColumns returns the rune offset of the " : " separator on every
+// numbered row in the captured output.
+func colonColumns(out string) map[string]int {
+	cols := map[string]int{}
+	for _, ln := range strings.Split(out, "\n") {
+		ln = strings.TrimRight(ln, "\r")
+		if !rowRe.MatchString(ln) {
+			continue
+		}
+		if i := strings.Index(ln, " : "); i >= 0 {
+			cols[ln] = len([]rune(ln[:i]))
+		}
+	}
+	return cols
+}
+
+// sampleResults builds a StepResults with every branch of the summary
+// populated, so the rendering tests exercise real output rather than zeros.
+func sampleResults() StepResults {
+	return StepResults{
+		TotalDeleted: 1234,
+		TotalFailed:  7,
+		StepCounts:   [12]int64{0, 400, 300, 120, 30, 90, 200, 80, 14, 0, 0, 0},
+		Ram: RamResult{
+			FreedMB:   2048,
+			BeforePct: 78.4,
+			AfterPct:  61.2,
+			DropPct:   17.2,
+			OpsRun:    []string{"flush", "standby"},
+		},
+		RecycleBinBytes:   1048576,
+		DeepCleanupRan:    true,
+		DeepCleanupFailed: false,
+	}
+}
+
+// TestMainMenuColumnsAlignOnScreen renders the real main menu and checks that
+// every numbered row puts its " : " in the same column. The sub-options form
+// their own indented group, so they are allowed their own column.
+func TestMainMenuColumnsAlignOnScreen(t *testing.T) {
+	original := ActiveLanguage()
+	defer SetLanguage(original)
+
+	cfg := DefaultConfig()
+	cfg.DeepCleanup = 1
+
+	for _, code := range localeCodes(t) {
+		SetLanguage(code)
+		out := captureStdout(t, func() {
+			DrawMainMenu(cfg, "Microsoft Windows ", "Version 10.0.0", "PC", "user")
+		})
+
+		want := -1
+		for line, col := range colonColumns(out) {
+			if want == -1 {
+				want = col
+			}
+			if col != want {
+				t.Errorf("[%s] main menu column mismatch (%d vs %d): %q", code, col, want, line)
+			}
+		}
+		if want == -1 {
+			t.Errorf("[%s] main menu produced no numbered rows", code)
+		}
+	}
+}
+
+// TestSummaryColumnsAlignOnScreen is the regression test for the Deep Cleanup
+// row, which carried hand-typed spacing and sat one column off from every
+// other summary row even in English.
+func TestSummaryColumnsAlignOnScreen(t *testing.T) {
+	original := ActiveLanguage()
+	defer SetLanguage(original)
+
+	cfg := DefaultConfig()
+	cfg.DeepCleanup = 1
+	results := sampleResults()
+
+	for _, code := range localeCodes(t) {
+		SetLanguage(code)
+		out := captureStdout(t, func() { PrintSummary(cfg, results) })
+
+		want := -1
+		for line, col := range colonColumns(out) {
+			if want == -1 {
+				want = col
+			}
+			if col != want {
+				t.Errorf("[%s] summary column mismatch (%d vs %d): %q", code, col, want, line)
+			}
+		}
+		if want == -1 {
+			t.Errorf("[%s] summary produced no numbered rows", code)
+		}
+	}
+}
+
+// TestNoRawKeysOnScreen is the end-to-end guard against a mistyped key: if a
+// lookup fails, T returns the key itself, which would appear on screen as
+// literal text like "summary.total". Nothing the user sees should look like
+// a dotted identifier.
+func TestNoRawKeysOnScreen(t *testing.T) {
+	original := ActiveLanguage()
+	defer SetLanguage(original)
+
+	// Matches bare dotted identifiers such as "cleaner.bin_freed". URLs and
+	// filenames on screen (github.com/..., cleanmgr.exe) are excluded by
+	// requiring the whole token to be a key-shaped word.
+	keyish := regexp.MustCompile(`(?m)(^|\s)[a-z]+(\.[a-z0-9_]+){1,3}(\s|$)`)
+
+	allowed := []string{"cleanmgr.exe", "qc.exe", "github.com", "cleaner_config.dat"}
+
+	cfg := DefaultConfig()
+	cfg.DeepCleanup = 1
+	results := sampleResults()
+
+	for _, code := range localeCodes(t) {
+		SetLanguage(code)
+
+		out := captureStdout(t, func() {
+			DrawMainMenu(cfg, "Microsoft Windows ", "Version 10.0.0", "PC", "user")
+			PrintSummary(cfg, results)
+			for i := 1; i <= 12; i++ {
+				StepSkipped(i)
+			}
+			PrintHelp()
+		})
+
+		for _, m := range keyish.FindAllString(out, -1) {
+			token := strings.TrimSpace(m)
+			skip := false
+			for _, a := range allowed {
+				if strings.Contains(token, a) {
+					skip = true
+					break
+				}
+			}
+			if !skip {
+				t.Errorf("[%s] untranslated key leaked to screen: %q", code, token)
+			}
+		}
+	}
+}
+
+// TestCenterInBox keeps headings inside the 41-column rule and centered.
+func TestCenterInBox(t *testing.T) {
+	for _, s := range []string{"CLEANING SUMMARY", "CONFIGURAR OPCIONES DE LIMPIEZA", "X"} {
+		got := centerInBox(s)
+		if !strings.HasSuffix(got, s) {
+			t.Errorf("centerInBox(%q) = %q, want it to end with the input", s, got)
+		}
+		if len([]rune(got)) > boxWidth {
+			t.Errorf("centerInBox(%q) is %d wide, exceeds boxWidth %d", s, len([]rune(got)), boxWidth)
+		}
+		lead := len([]rune(got)) - len([]rune(s))
+		if want := (boxWidth - len([]rune(s))) / 2; lead != want {
+			t.Errorf("centerInBox(%q) indented %d, want %d", s, lead, want)
+		}
+	}
+}

--- a/ui_test.go
+++ b/ui_test.go
@@ -190,6 +190,62 @@ func TestNoRawKeysOnScreen(t *testing.T) {
 	}
 }
 
+// TestQuickEditDisabledMode covers the console flag arithmetic behind the
+// click-to-freeze fix. Clicking the window used to put the console into
+// selection mode, which blocks every write - so the app appeared to hang,
+// and could not even print a warning, because printing was what was blocked.
+//
+// The syscall itself cannot be tested here: `go test` redirects the standard
+// handles, so there is no console to query. The bit maths is the part that
+// can silently go wrong, and it is what this checks.
+func TestQuickEditDisabledMode(t *testing.T) {
+	const (
+		processedInput = 0x0001 // ENABLE_PROCESSED_INPUT
+		mouseInput     = 0x0010 // ENABLE_MOUSE_INPUT
+	)
+
+	cases := []struct {
+		name string
+		in   uint32
+	}{
+		{"typical default console", processedInput | mouseInput | ENABLE_QUICK_EDIT_MODE},
+		{"quick edit already off", processedInput | mouseInput},
+		{"extended flags already set", ENABLE_EXTENDED_FLAGS | ENABLE_QUICK_EDIT_MODE},
+		{"no flags at all", 0},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := quickEditDisabledMode(c.in)
+
+			if got&ENABLE_QUICK_EDIT_MODE != 0 {
+				t.Error("QuickEdit is still enabled - clicking the window would still freeze the app")
+			}
+			// Without this flag Windows ignores the QuickEdit change entirely.
+			if got&ENABLE_EXTENDED_FLAGS == 0 {
+				t.Error("ENABLE_EXTENDED_FLAGS not set - the QuickEdit change would be ignored")
+			}
+			// Unrelated settings belong to the user, not to us.
+			preserved := c.in &^ (ENABLE_QUICK_EDIT_MODE | ENABLE_EXTENDED_FLAGS)
+			if got&preserved != preserved {
+				t.Errorf("other console flags were lost: input 0x%X, output 0x%X", c.in, got)
+			}
+		})
+	}
+}
+
+// TestRestoreConsoleModeIsSafeWithoutAConsole documents that exiting must not
+// panic when the mode was never captured - which is the case for every test
+// run, and for any environment where the handle is redirected.
+func TestRestoreConsoleModeIsSafeWithoutAConsole(t *testing.T) {
+	saved, savedFlag := origInputMode, origInputModeSaved
+	defer func() { origInputMode, origInputModeSaved = saved, savedFlag }()
+
+	origInputMode, origInputModeSaved = 0, false
+	RestoreConsoleMode() // must be a no-op, not a crash
+	RestoreConsoleMode()
+}
+
 // TestCenterInBox keeps headings inside the 41-column rule and centered.
 func TestCenterInBox(t *testing.T) {
 	for _, s := range []string{"CLEANING SUMMARY", "CONFIGURAR OPCIONES DE LIMPIEZA", "X"} {

--- a/version.go
+++ b/version.go
@@ -53,14 +53,14 @@ const (
 
 // Version and Commit are overridable at build time:
 //
-//	go build -ldflags "-X main.Version=2.3.0" -o qc.exe
+//	go build -ldflags "-X main.Version=2.4.0" -o qc.exe
 //
 // Version carries a real default so an unflagged `go build` still produces a
 // correctly-labelled binary rather than "dev". Build timestamps are
 // deliberately not recorded or shown - they add noise to every version check
 // and make otherwise identical builds look different.
 var (
-	Version = "2.3.0"
+	Version = "2.4.0"
 	Commit  = ""
 )
 
@@ -133,10 +133,10 @@ func PrintAbout() {
 	fmt.Println()
 	fmt.Printf("  %s v%s%s\n", AppName, Version, build)
 	fmt.Printf("  %s  -  %s\n", Author, Repo)
-	fmt.Println("  GPL-3.0-or-later - free software, with no warranty")
+	fmt.Printf("  %s\n", T("version.license"))
 	fmt.Println()
 	fmt.Printf("  SHA-256  %s\n", SelfSHA256())
-	fmt.Printf("  Compare with the checksum on %s/releases\n", Repo)
+	fmt.Printf("  %s\n", Tf("version.compare", Repo))
 	fmt.Println()
 }
 
@@ -144,13 +144,13 @@ func PrintAbout() {
 // interface; these flags exist for identity checks and scripting.
 func PrintHelp() {
 	fmt.Println()
-	fmt.Printf("  %s v%s - Windows system cleaner and RAM optimizer\n", AppName, Version)
+	fmt.Printf("  %s\n", Tf("help.tagline", AppName, Version))
 	fmt.Println()
-	fmt.Printf("  Usage: %s [flag]\n", AppShort)
+	fmt.Printf("  %s\n", Tf("help.usage", AppShort))
 	fmt.Println()
-	fmt.Println("    (no flag)          Launch the interactive menu")
-	fmt.Println("    -v, --version      Version, author, license and checksum")
-	fmt.Println("    -h, --help         Show this help")
+	fmt.Printf("    %s\n", T("help.no_flag"))
+	fmt.Printf("    %s\n", T("help.version"))
+	fmt.Printf("    %s\n", T("help.help"))
 	fmt.Println()
 }
 


### PR DESCRIPTION
Quiesce now follows the Windows display language, falling back to English.
English and Spanish ship; adding a language takes one .toml file and two
one-line additions.

Uses nicksnyder/go-i18n.

## Changes
- Translations in locales/*.toml, embedded in the binary
- Language picker on the settings screen (L), numbered list with a tick
  on the active language
- LANGUAGE= override in cleaner_config.dat, preserved across saves
- Console switched to UTF-8 so accents render correctly
- Columns measured at runtime instead of hand-typed spaces

## Fixes
- Saving settings no longer erases a LANGUAGE= line
- [12] Deep Cleanup summary row now aligns with the other rows

## Tests
New suite covers missing keys, mismatched placeholders, column alignment
in every language, and config round-tripping. CI runs build, vet, gofmt,
tests on Go 1.23 and stable, and cross-builds for amd64 and 386.

Closes #8